### PR TITLE
chore: remove unused import in consumers.py

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -67,7 +67,6 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
 
         # --- PATCH: Enforce LiteLLM-only endpoint and suppress OpenAI tracing/telemetry ---
         import logging
-        import os
         if os.environ.get("LITELLM_BASE_URL") or os.environ.get("OPENAI_BASE_URL"):
             logging.getLogger("openai.agents").setLevel(logging.CRITICAL)
             try:


### PR DESCRIPTION
## Summary
- Remove redundant `import os` statement inside a function body in `consumers.py`
- The `os` module is already imported at the top of the file (line 2), making this duplicate import unnecessary

## Changes
- Delete line 70 (`import os`) from `src/swarm/consumers.py`

## Testing
- No functional change; purely a code cleanup