### PR TITLE
🔒 Fix Command Injection in shell_exec_with_approval

### DIFF
--- a/src/swarm/blueprints/codey/blueprint_codey.py
+++ b/src/swarm/blueprints/codey/blueprint_codey.py
@@ -13,6 +13,8 @@ Self-healing, fileops-enabled, swarm-scalable.
 import asyncio
 import logging
 import os
+import shlex
+import subprocess
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -929,8 +931,8 @@ class CodeyBlueprint(BlueprintBase):
     def shell_exec_with_approval(self, command):
         self.check_approval("tool.shell.exec", command=command)
         # Simulate shell exec (for demo)
-        import subprocess
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        args = shlex.split(command)
+        result = subprocess.run(args, shell=False, capture_output=True, text=True)
         print_operation_box(
             op_type="Shell Exec",
             results=[f"Command output: {result.stdout.strip()}"],

--- a/tests/cli/test_config_secrets_and_env_expansion.py
+++ b/tests/cli/test_config_secrets_and_env_expansion.py
@@ -22,6 +22,9 @@ SWARM_MODULE = "src.swarm.extensions.launchers.swarm_cli"
 
 def run_cli(env_overrides: dict, args: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
+    # Ensure XDG_CONFIG_HOME doesn't override our HOME isolation if not intended
+    if "HOME" in env_overrides and "XDG_CONFIG_HOME" not in env_overrides:
+        env.pop("XDG_CONFIG_HOME", None)
     env.update(env_overrides)
 
     cmd = [sys.executable, "-m", SWARM_MODULE] + args


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection in the `CodeyBlueprint.shell_exec_with_approval` method.
⚠️ **Risk:** The potential impact if left unfixed is high, as an attacker could execute arbitrary shell commands on the system running the agent by injecting meta-characters into the command string (e.g., using `;`, `&&`, or `||`).
🛡️ **Solution:** The fix addresses the vulnerability by avoiding the use of `shell=True` in `subprocess.run`. Instead, it uses `shlex.split` to safely parse the command into a list of arguments and executes it directly with `shell=False`. This ensures that the shell does not interpret any special characters as command separators or redirects.


---
*PR created automatically by Jules for task [4622495280475509466](https://jules.google.com/task/4622495280475509466) started by @matthewhand*