### PR TITLE
Refactor tool call check in context_utils

### DIFF
--- a/src/swarm/utils/context_utils.py
+++ b/src/swarm/utils/context_utils.py
@@ -157,11 +157,10 @@ def _truncate_sophisticated(messages: list[dict[str, Any]], model: str, max_toke
                      prev_tokens = 9999
                  if prev_msg.get("role") == "assistant" and isinstance(prev_msg.get("tool_calls"), list):
                      assistant_tool_calls = prev_msg.get("tool_calls", [])
-                     # ---> FIX: Check if this specific tool call ID is present AND if the assistant ONLY has ONE tool call <---
                      has_this_call = any(tc.get("id") == tool_call_id for tc in assistant_tool_calls if isinstance(tc, dict))
-                     is_single_call_assistant = len(assistant_tool_calls) == 1
 
                      if has_this_call:
+                          is_single_call_assistant = len(assistant_tool_calls) == 1
                           pair_found = True
                           if not is_single_call_assistant:
                               logger.debug(f"      Found assistant pair at {assistant_idx}, but it has multiple tool calls ({len(assistant_tool_calls)}). Deferring to Case 2.")


### PR DESCRIPTION
Refactored the sophisticated truncation logic in `src/swarm/utils/context_utils.py` to correctly check for specific tool call IDs and identify single-call assistant messages. The `is_single_call_assistant` calculation was moved inside the `if has_this_call` block for better efficiency and the placeholder FIX comment was removed. Verified the changes with standalone test scripts simulating both single and multi-tool call scenarios.

---
*PR created automatically by Jules for task [13972753325151576249](https://jules.google.com/task/13972753325151576249) started by @matthewhand*