### PR TITLE
🧪 [testing improvement: custom_json_dumps]

### DIFF
--- a/tests/unit/test_general_utils_json.py
+++ b/tests/unit/test_general_utils_json.py
@@ -1,0 +1,47 @@
+import datetime
+import json
+import pytest
+from src.swarm.utils.general_utils import serialize_datetime, custom_json_dumps
+
+class TestSerializeDatetime:
+    def test_serialize_datetime_obj(self):
+        dt = datetime.datetime(2023, 10, 27, 12, 0, 0)
+        assert serialize_datetime(dt) == "2023-10-27T12:00:00"
+
+    def test_serialize_string(self):
+        s = "2023-10-27T12:00:00"
+        assert serialize_datetime(s) == s
+
+    def test_serialize_unsupported_type(self):
+        with pytest.raises(TypeError) as excinfo:
+            serialize_datetime(123)
+        assert "Type <class 'int'> not serializable" in str(excinfo.value)
+
+class TestCustomJsonDumps:
+    def test_dumps_basic(self):
+        data = {"key": "value"}
+        assert custom_json_dumps(data) == json.dumps(data)
+
+    def test_dumps_with_datetime(self):
+        dt = datetime.datetime(2023, 10, 27, 12, 0, 0)
+        data = {"time": dt}
+        expected = json.dumps({"time": "2023-10-27T12:00:00"})
+        assert custom_json_dumps(data) == expected
+
+    def test_dumps_with_nested_datetime(self):
+        dt = datetime.datetime(2023, 10, 27, 12, 0, 0)
+        data = {"outer": {"inner": dt}}
+        expected = json.dumps({"outer": {"inner": "2023-10-27T12:00:00"}})
+        assert custom_json_dumps(data) == expected
+
+    def test_dumps_with_kwargs(self):
+        data = {"a": 1, "b": 2}
+        # indent=4 is a kwarg passed to json.dumps
+        result = custom_json_dumps(data, indent=4)
+        assert result == json.dumps(data, indent=4)
+        assert "\n    " in result
+
+    def test_dumps_raises_type_error_for_unsupported(self):
+        data = {"set": {1, 2, 3}}
+        with pytest.raises(TypeError):
+            custom_json_dumps(data)


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap for `custom_json_dumps` and `serialize_datetime` in `src/swarm/utils/general_utils.py`.
📊 **Coverage:**
- `serialize_datetime`: tested with `datetime.datetime` objects, strings, and unsupported types (integers).
- `custom_json_dumps`: tested with basic dicts, nested dicts containing datetime objects, and passing keyword arguments like `indent`.
- Error handling: verified `TypeError` is raised for non-serializable types like `set`.
✨ **Result:** Increased the reliability and coverage of core utility functions, ensuring stable JSON serialization of datetime-heavy payloads across the framework.

---
*PR created automatically by Jules for task [16471455918804581912](https://jules.google.com/task/16471455918804581912) started by @matthewhand*