### PR TITLE
🧹 Remove unused import 'os' from spinner.py

### DIFF
--- a/src/swarm/extensions/blueprint/spinner.py
+++ b/src/swarm/extensions/blueprint/spinner.py
@@ -2,7 +2,6 @@
 Simple terminal spinner for interactive feedback during long operations.
 """
 
-import os
 import sys
 import threading
 import time
@@ -26,7 +25,7 @@ class Spinner:
         self.is_tty = sys.stdout.isatty()
         self.enabled = self.interactive and self.is_tty
         self.running = False
-        self.thread: Optional[threading.Thread] = None
+        self.thread: threading.Thread | None = None
         self.status = ""
         self.index = 0
 


### PR DESCRIPTION
This change improves the code hygiene of the `spinner.py` extension by removing a redundant import and modernization of type hints. 

🎯 **What:** Removed unused `import os` and updated `Optional[threading.Thread]` to `threading.Thread | None`.
💡 **Why:** Reduces technical debt and improves readability by following modern Python standards (PEP 604). It also fixes a potential `NameError` as `Optional` was used but not imported.
✅ **Verification:** Verified by running the spinner directly and through a standalone test suite in the development environment.
✨ **Result:** Cleaner code and improved maintainability.

---
*PR created automatically by Jules for task [5609437812541064965](https://jules.google.com/task/5609437812541064965) started by @matthewhand*