### PR TITLE
🧪 [testing improvement] Add tests for is_enable_wagtail feature toggle

### DIFF
--- a/src/swarm/utils/env_utils.py
+++ b/src/swarm/utils/env_utils.py
@@ -162,7 +162,7 @@ def get_fly_api_token() -> str | None:
 # Feature Flags
 def is_enable_wagtail() -> bool:
     """Check if Wagtail is enabled."""
-    return os.getenv('ENABLE_WAGTAIL', 'false').lower() in ('1', 'true', 'yes')
+    return is_truthy(os.getenv('ENABLE_WAGTAIL', 'false'))
 
 
 def is_enable_saml_idp() -> bool:

--- a/tests/utils/test_env_utils.py
+++ b/tests/utils/test_env_utils.py
@@ -10,6 +10,7 @@ from swarm.utils.env_utils import (
     get_swarm_config_path,
     get_swarm_log_level,
     is_django_debug,
+    is_enable_wagtail,
     is_truthy,
 )
 
@@ -35,6 +36,24 @@ def test_get_django_secret_key():
 def test_is_django_debug(value, expected):
     with patch.dict(os.environ, {"DJANGO_DEBUG": value}):
         assert is_django_debug() is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("true", True),
+        ("1", True),
+        ("t", True),
+        ("yes", True),
+        ("y", True),
+        ("false", False),
+        ("0", False),
+        ("", False),
+    ],
+)
+def test_is_enable_wagtail(value, expected):
+    with patch.dict(os.environ, {"ENABLE_WAGTAIL": value}):
+        assert is_enable_wagtail() is expected
 
 
 def test_get_django_allowed_hosts():


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `is_enable_wagtail` configuration toggle in `src/swarm/utils/env_utils.py` and refactored the function to use the centralized `is_truthy` utility.

📊 **Coverage:** Parametrized tests now cover truthy ('true', '1', 'yes', 't', 'y') and falsy ('false', '0', '') environment variable values.

✨ **Result:** Improved test coverage for environment utility functions and ensured consistent boolean parsing across feature flags.

---
*PR created automatically by Jules for task [2934981526157595983](https://jules.google.com/task/2934981526157595983) started by @matthewhand*