### PR TITLE
🔒 [security fix] Fix Command Injection in Codey blueprint

### DIFF
--- a/src/swarm/blueprints/codey/blueprint_codey.py
+++ b/src/swarm/blueprints/codey/blueprint_codey.py
@@ -13,6 +13,8 @@ Self-healing, fileops-enabled, swarm-scalable.
 import asyncio
 import logging
 import os
+import shlex
+import subprocess
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -929,8 +931,16 @@ class CodeyBlueprint(BlueprintBase):
     def shell_exec_with_approval(self, command):
         self.check_approval("tool.shell.exec", command=command)
         # Simulate shell exec (for demo)
-        import subprocess
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        try:
+            args = shlex.split(command)
+            if not args:
+                return "Error: Empty command."
+            result = subprocess.run(args, shell=False, capture_output=True, text=True)
+        except ValueError as e:
+            return f"Error: Failed to parse command: {e}"
+        except Exception as e:
+            return f"Error: Command execution failed: {e}"
+
         print_operation_box(
             op_type="Shell Exec",
             results=[f"Command output: {result.stdout.strip()}"],


### PR DESCRIPTION
### 🎯 What
Fixed a command injection vulnerability in the Codey blueprint's `shell_exec_with_approval` method.

### ⚠️ Risk
The original code used `subprocess.run(command, shell=True)`, which allowed an attacker (or a malicious/hallucinated agent prompt) to execute arbitrary shell commands by including shell metacharacters like `;`, `&&`, or `|` in the command string. This could lead to full system compromise.

### 🛡️ Solution
The fix implements the following security best practices:
1.  **Disable Shell Execution**: Switched to `shell=False` to prevent the operating system from interpreting the command string via a shell (e.g., `/bin/sh`).
2.  **Secure Tokenization**: Used `shlex.split(command)` to safely break the command string into a list of arguments, ensuring that shell metacharacters are treated as literal characters within arguments.
3.  **Robust Error Handling**: Added a `try-except` block to catch `ValueError` (raised by `shlex` on unclosed quotes) and other execution exceptions, returning a clear error message instead of crashing.
4.  **Edge Case Handling**: Explicitly check for empty commands after splitting.
5.  **Clean Code**: Moved `subprocess` and `shlex` imports to the top of the file per PEP 8.

---
*PR created automatically by Jules for task [14944322991747537880](https://jules.google.com/task/14944322991747537880) started by @matthewhand*