### PR TITLE
🧪 [testing improvement] Add tests for JSON decode error in tool_executor

### DIFF
--- a/tests/core/test_tool_executor.py
+++ b/tests/core/test_tool_executor.py
@@ -318,18 +318,42 @@ class TestHandleToolCalls:
 
     @pytest.mark.asyncio
     async def test_handles_invalid_json_arguments(self):
-        """Invalid JSON arguments are handled gracefully."""
+        """Invalid JSON arguments are handled gracefully and logged as error."""
         tool_call = make_tool_call("call-bad-json", "test_tool", "not valid json")
 
         def test_tool(**kwargs):
             return "ok"
 
-        response = await handle_tool_calls(
-            [tool_call], [test_tool], {}, debug=False
-        )
+        with patch("swarm.tool_executor.logger") as mock_logger:
+            response = await handle_tool_calls(
+                [tool_call], [test_tool], {}, debug=False
+            )
 
         # Should still execute with empty args
         assert response.messages[0]["content"] == "ok"
+        mock_logger.error.assert_called()
+        error_msg = mock_logger.error.call_args[0][0]
+        assert "Failed to parse JSON arguments for tool 'test_tool'" in error_msg
+        assert "not valid json" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_handles_non_dict_json_arguments(self):
+        """JSON arguments that are not a dict are handled and logged as warning."""
+        tool_call = make_tool_call("call-non-dict", "test_tool", "[1, 2, 3]")
+
+        def test_tool(**kwargs):
+            return "ok"
+
+        with patch("swarm.tool_executor.logger") as mock_logger:
+            response = await handle_tool_calls(
+                [tool_call], [test_tool], {}, debug=False
+            )
+
+        # Should still execute with empty args
+        assert response.messages[0]["content"] == "ok"
+        mock_logger.warning.assert_called()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Parsed arguments for tool 'test_tool' is not a dictionary" in warning_msg
 
     @pytest.mark.asyncio
     async def test_handles_tool_exception(self):


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing test for `json.JSONDecodeError` when parsing tool arguments in `handle_tool_calls`.
- Missing test for when parsed tool arguments are valid JSON but not a dictionary.

📊 **Coverage:** What scenarios are now tested
- **Invalid JSON:** Passed "not valid json" to `handle_tool_calls` and asserted that `logger.error` is called and execution continues with an empty dictionary.
- **Non-dict JSON:** Passed "[1, 2, 3]" to `handle_tool_calls` and asserted that `logger.warning` is called and execution continues with an empty dictionary.

✨ **Result:** The improvement in test coverage
- Increased code coverage for `src/swarm/tool_executor.py`.
- Ensured that the fallback logic and observability (logging) for argument parsing errors are correctly functioning and won't regress.

---
*PR created automatically by Jules for task [7186146469463691126](https://jules.google.com/task/7186146469463691126) started by @matthewhand*