### PR TITLE
Refine Agent Instructions Table Schema in Poets Blueprint

### DIFF
--- a/src/swarm/blueprints/poets/blueprint_poets.py
+++ b/src/swarm/blueprints/poets/blueprint_poets.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # --- Database Constants ---
 DB_FILE_NAME = "swarm_instructions.db"
 DB_PATH = Path(project_root) / DB_FILE_NAME
-TABLE_NAME = "agent_instructions"
+TABLE_NAME = "agent_instructions" # agent_name TEXT PRIMARY KEY, instruction_text TEXT NOT NULL, model_profile TEXT DEFAULT 'default'
 
 # --- Agent Instructions ---
 # Shared knowledge base for collaboration context
@@ -316,12 +316,12 @@ class PoetsBlueprint(BlueprintBase):
             DB_PATH.parent.mkdir(parents=True, exist_ok=True)
             with sqlite3.connect(DB_PATH) as conn:
                 cursor = conn.cursor()
-                # FIX: Define the table schema instead of ...
+                # The table schema is explicitly defined to ensure consistent agent configuration storage.
                 cursor.execute(f"""
                     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
                         agent_name TEXT PRIMARY KEY,
-                        instruction_text TEXT,
-                        model_profile TEXT
+                        instruction_text TEXT NOT NULL,
+                        model_profile TEXT DEFAULT 'default'
                     )
                 """)
                 logger.debug(f"Table '{TABLE_NAME}' ensured in {DB_PATH}")


### PR DESCRIPTION
This change refines the SQLite table schema for agent instructions in the Poets blueprint. It ensures that 'instruction_text' is NOT NULL and 'model_profile' has a default value of 'default', matching the schema used in other blueprints like MissionImprobable. The legacy placeholder comment has been replaced with a more informative one, and a reference comment has been added to the table name constant. Verification was performed using a mock-based script and syntax checks.

---
*PR created automatically by Jules for task [18199682901264052305](https://jules.google.com/task/18199682901264052305) started by @matthewhand*