### PR TITLE
🧹 Remove unused wildcard import in config_manager.py

### DIFF
--- a/src/swarm/core/config_manager.py
+++ b/src/swarm/core/config_manager.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 from typing import Any
 
-from swarm.core.utils.logger import *
 from swarm.extensions.cli.utils.prompt_user import prompt_user
 from swarm.settings import DEBUG
 


### PR DESCRIPTION
Removed the unused wildcard import `from swarm.core.utils.logger import *` in `src/swarm/core/config_manager.py` to improve maintainability and readability. Confirmed that no symbols from the imported module were being used. Verified the change with a syntax check and a successful import test in a mocked environment.

---
*PR created automatically by Jules for task [1699699921636214633](https://jules.google.com/task/1699699921636214633) started by @matthewhand*