### PR TITLE
🔒 [security fix] Fix Command Injection vulnerabilities by removing shell=True

### DIFF
--- a/src/swarm/blueprints/chatbot/blueprint_chatbot.py
+++ b/src/swarm/blueprints/chatbot/blueprint_chatbot.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shlex
 import sys
 from pathlib import Path
 from typing import Any, ClassVar
@@ -121,7 +122,8 @@ class ChatbotBlueprint(BlueprintBase):
     def execute_shell_command(self, command: str) -> str:
         import subprocess
         try:
-            result = subprocess.run(command, shell=True, capture_output=True, text=True)
+            command_list = shlex.split(command)
+            result = subprocess.run(command_list, shell=False, capture_output=True, text=True)
             return result.stdout + result.stderr
         except Exception as e:
             return f"ERROR: {e}"

--- a/src/swarm/blueprints/codey/blueprint_codey.py
+++ b/src/swarm/blueprints/codey/blueprint_codey.py
@@ -13,6 +13,7 @@ Self-healing, fileops-enabled, swarm-scalable.
 import asyncio
 import logging
 import os
+import shlex
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -930,7 +931,8 @@ class CodeyBlueprint(BlueprintBase):
         self.check_approval("tool.shell.exec", command=command)
         # Simulate shell exec (for demo)
         import subprocess
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True)
         print_operation_box(
             op_type="Shell Exec",
             results=[f"Command output: {result.stdout.strip()}"],

--- a/src/swarm/blueprints/echocraft/blueprint_echocraft.py
+++ b/src/swarm/blueprints/echocraft/blueprint_echocraft.py
@@ -2,6 +2,7 @@
 import json  # Import json for writing to file
 import logging
 import os
+import shlex
 import subprocess
 import sys  # Import sys for stderr
 import threading
@@ -51,7 +52,8 @@ def execute_shell_command(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
         output = f"Exit Code: {result.returncode}\n"
         if result.stdout:
             output += f"STDOUT:\n{result.stdout}\n"
@@ -245,7 +247,8 @@ class EchoCraftBlueprint(BlueprintBase):
         try:
             import os
             timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-            result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+            command_list = shlex.split(command)
+            result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
             output = f"Exit Code: {result.returncode}\n"
             if result.stdout:
                 output += f"STDOUT:\n{result.stdout}\n"

--- a/src/swarm/blueprints/jeeves/blueprint_jeeves.py
+++ b/src/swarm/blueprints/jeeves/blueprint_jeeves.py
@@ -14,6 +14,7 @@ assert hasattr(__file__, "__str__")
 import asyncio
 import logging
 import os
+import shlex
 import sys
 import time
 from datetime import datetime
@@ -149,7 +150,8 @@ def list_files(directory: str = '.') -> str:
 def execute_shell_command(command: str) -> str:
     import subprocess
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True)
         return result.stdout + result.stderr
     except Exception as e:
         return f"ERROR: {e}"

--- a/src/swarm/blueprints/mcp_demo/blueprint_mcp_demo.py
+++ b/src/swarm/blueprints/mcp_demo/blueprint_mcp_demo.py
@@ -16,6 +16,7 @@ import glob
 import json
 import logging
 import os
+import shlex
 import subprocess
 import sys
 from datetime import datetime
@@ -169,7 +170,8 @@ def execute_shell_command(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
         output = f"Exit Code: {result.returncode}\n"
         if result.stdout:
             output += f"STDOUT:\n{result.stdout}\n"

--- a/src/swarm/blueprints/mission_improbable/blueprint_mission_improbable.py
+++ b/src/swarm/blueprints/mission_improbable/blueprint_mission_improbable.py
@@ -6,6 +6,7 @@ Self-healing, fileops-enabled, swarm-scalable.
 """
 import logging
 import os
+import shlex
 import sqlite3  # Use standard sqlite3 module
 import subprocess
 import sys
@@ -78,7 +79,8 @@ def execute_shell_command(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
         output = f"Exit Code: {result.returncode}\n"
         if result.stdout:
             output += f"STDOUT:\n{result.stdout}\n"

--- a/src/swarm/blueprints/nebula_shellz/blueprint_nebula_shellz.py
+++ b/src/swarm/blueprints/nebula_shellz/blueprint_nebula_shellz.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import shlex
 import subprocess
 import sys
 from typing import Any, ClassVar
@@ -129,13 +130,14 @@ def _execute_shell_command_raw(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
+        command_list = shlex.split(command)
         result = subprocess.run(
-            command,
+            command_list,
             capture_output=True,
             text=True,
             timeout=timeout,
             check=False,
-            shell=True,
+            shell=False,
         )
         output = (
             f"Exit Code: {result.returncode}\n"

--- a/src/swarm/blueprints/poets/blueprint_poets.py
+++ b/src/swarm/blueprints/poets/blueprint_poets.py
@@ -7,6 +7,7 @@ Self-healing, fileops-enabled, swarm-scalable.
 import logging
 import os
 import random
+import shlex
 import sqlite3  # Use standard sqlite3 module
 import sys
 from pathlib import Path
@@ -162,7 +163,8 @@ def execute_shell_command(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
         output = f"Exit Code: {result.returncode}\n"
         if result.stdout:
             output += f"STDOUT:\n{result.stdout}\n"

--- a/src/swarm/blueprints/rue_code/blueprint_rue_code.py
+++ b/src/swarm/blueprints/rue_code/blueprint_rue_code.py
@@ -6,6 +6,7 @@ Self-healing, fileops-enabled, swarm-scalable.
 """
 import logging
 import os
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -53,9 +54,10 @@ def execute_shell_command(command: str) -> str:
     try:
         import os
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
+        command_list = shlex.split(command)
         result = subprocess.run(
-            command,
-            shell=True,
+            command_list,
+            shell=False,
             check=False, # Don't raise exception on non-zero exit code
             capture_output=True,
             text=True,
@@ -100,9 +102,10 @@ def execute_shell_command(command: str) -> str:
     """
     logger.info(f"Executing shell command: {command}")
     try:
+        command_list = shlex.split(command)
         result = subprocess.run(
-            command,
-            shell=True,
+            command_list,
+            shell=False,
             check=False, # Don't raise exception on non-zero exit code
             capture_output=True,
             text=True,
@@ -207,7 +210,8 @@ def list_files_fileops(directory: str = '.') -> str:
 def execute_shell_command_fileops(command: str) -> str:
     import subprocess
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True)
         return result.stdout + result.stderr
     except Exception as e:
         return f"ERROR: {e}"

--- a/src/swarm/blueprints/suggestion/blueprint_suggestion.py
+++ b/src/swarm/blueprints/suggestion/blueprint_suggestion.py
@@ -12,6 +12,7 @@ Self-healing, fileops-enabled, swarm-scalable.
 
 import logging
 import os
+import shlex
 import sys
 from datetime import datetime
 from typing import Any, ClassVar
@@ -113,7 +114,8 @@ def execute_shell_command(command: str) -> str:
         import os
         import subprocess
         timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+        command_list = shlex.split(command)
+        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
         output = f"Exit Code: {result.returncode}\n"
         if result.stdout:
             output += f"STDOUT:\n{result.stdout}\n"

--- a/src/swarm/extensions/cli/commands/team_wizard.py
+++ b/src/swarm/extensions/cli/commands/team_wizard.py
@@ -361,10 +361,11 @@ def _render_blueprint_code(spec: TeamSpec, template: str = "simple") -> str:
             except Exception as e:
                 return "ERROR: " + str(e)
         def execute_shell_command(command: str) -> str:
-            import os, subprocess
+            import os, shlex, subprocess
             try:
                 timeout = int(os.getenv("SWARM_COMMAND_TIMEOUT", "60"))
-                result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)
+                command_list = shlex.split(command)
+                result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)
                 output = "Exit Code: " + str(result.returncode) + "\\n"
                 if result.stdout:
                     output += "STDOUT:\\n" + result.stdout + "\\n"

--- a/src/swarm/views/agent_creator_views.py
+++ b/src/swarm/views/agent_creator_views.py
@@ -116,6 +116,7 @@ class BlueprintCodeValidator:
             # Run flake8 (lighter than pylint)
             result = subprocess.run(
                 ['flake8', '--select=E,W,F', '--ignore=E501,W503', temp_file],
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=10
@@ -619,9 +620,10 @@ def _render_swarm_blueprint_code(team: dict[str, Any]) -> str:
             "@function_tool\n"
             "def execute_shell_command(command: str) -> str:\n"
             "    try:\n"
-            "        import os, subprocess\n"
+            "        import os, shlex, subprocess\n"
             "        timeout = int(os.getenv(\"SWARM_COMMAND_TIMEOUT\", \"60\"))\n"
-            "        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout)\n"
+            "        command_list = shlex.split(command)\n"
+            "        result = subprocess.run(command_list, shell=False, capture_output=True, text=True, timeout=timeout)\n"
             "        output = f\"Exit Code: {result.returncode}\\n\"\n"
             "        if result.stdout:\n"
             "            output += \"STDOUT:\\n\" + result.stdout + \"\\n\"\n"


### PR DESCRIPTION
### 🎯 What:
Fixed a critical command injection vulnerability where user-supplied strings were passed to `subprocess.run(..., shell=True)`.

### ⚠️ Risk:
Leaving `shell=True` with unvalidated input allows attackers to execute arbitrary shell commands on the host system (e.g., via `; touch /tmp/pwned` or more malicious payloads). This could lead to full system compromise.

### 🛡️ Solution:
- Replaced `shell=True` with `shell=False` globally in the project.
- Utilized `shlex.split(command)` to safely tokenize command strings into argument lists for `subprocess.run`.
- Updated blueprint implementations for: `echocraft`, `mission_improbable`, `nebula_shellz`, `mcp_demo`, `rue_code`, `suggestion`, `codey`, `chatbot`, `poets`, and `jeeves`.
- Secured the `team_wizard` CLI tool and `agent_creator_views` web component, including the code generation templates they use.
- Verified all modified files for syntax correctness.
- Confirmed the fix using a targeted reproduction script.

---
*PR created automatically by Jules for task [3895585039769700448](https://jules.google.com/task/3895585039769700448) started by @matthewhand*