### PR TITLE
feat(spa): agent-creator page and settings expansion (ROADMAP 3.1)

### DIFF
--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Home, Settings, Bot, Book, Users, PlusCircle, MessageSquare, ShieldAlert, X } from 'lucide-react'
+import { Home, Settings, Bot, Book, Users, PlusCircle, MessageSquare, ShieldAlert, Wand2, X } from 'lucide-react'
 import { Button, Card, Alert, Badge, LoadingSpinner, ToastProvider } from './components/DaisyUI'
 import TeamsPage from './pages/TeamsPage'
 import BlueprintsPage from './pages/BlueprintsPage'
 import ChatPage from './pages/ChatPage'
 import SettingsPage from './pages/SettingsPage'
+import AgentCreatorPage from './pages/AgentCreatorPage'
 import { fetchBlueprints, fetchModels } from './lib/api'
 import { AuthProvider, useAuth } from './lib/AuthContext'
 
@@ -40,6 +41,10 @@ function App() {
                         <Book className="h-4 w-4 mr-1" />
                         Blueprints
                       </Link>
+                      <Link to="/agent-creator" className="btn btn-ghost btn-sm">
+                        <Wand2 className="h-4 w-4 mr-1" />
+                        Agent Creator
+                      </Link>
                     </div>
                   </div>
                   <div className="flex items-center space-x-4">
@@ -67,6 +72,7 @@ function App() {
                 <Route path="/chat" element={<ChatPage />} />
                 <Route path="/teams" element={<TeamsPage />} />
                 <Route path="/blueprints" element={<BlueprintsPage />} />
+                <Route path="/agent-creator" element={<AgentCreatorPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Routes>
             </div>
@@ -88,6 +94,10 @@ function App() {
               <Link to="/blueprints">
                 <Book className="h-5 w-5" />
                 <span className="btm-nav-label">Blueprints</span>
+              </Link>
+              <Link to="/agent-creator">
+                <Wand2 className="h-5 w-5" />
+                <span className="btm-nav-label">Creator</span>
               </Link>
               <Link to="/settings">
                 <Settings className="h-5 w-5" />

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -204,3 +204,158 @@ export function createTeam(team: CreateTeamRequest): Promise<Team> {
 export function deleteTeam(teamId: string): Promise<void> {
   return apiDelete(`/v1/teams/${encodeURIComponent(teamId)}/`)
 }
+
+// ---------------------------------------------------------------------------
+// Agent creator (swarm/views/agent_creator_views.py)
+//
+// /agent-creator/generate/ and /agent-creator/validate/ are plain Django POST
+// views protected by CsrfViewMiddleware (verified: they 403 without a CSRF
+// cookie + X-CSRFToken header). ensureCsrfCookie() primes the cookie via a
+// cheap GET to /login/ (which sets csrftoken); buildHeaders() then attaches
+// the matching X-CSRFToken header automatically.
+//
+// Saving deliberately uses POST /v1/blueprints/custom/ (a DRF view, CSRF-free
+// for token/anonymous access) instead of /agent-creator/save/: the latter
+// writes loose files under user_blueprints/ with no list/delete API, whereas
+// the custom-blueprints library gives the page a coherent list/save/delete
+// story against a single store.
+// ---------------------------------------------------------------------------
+
+/**
+ * Make sure Django's csrftoken cookie is set before calling CSRF-protected
+ * (non-DRF) endpoints. No-op when the cookie already exists.
+ */
+export async function ensureCsrfCookie(): Promise<void> {
+  if (getCookie('csrftoken')) return
+  try {
+    await fetch('/login/', { headers: { Accept: 'text/html' } })
+  } catch {
+    // Network failure: the subsequent POST will surface a real error.
+  }
+}
+
+/** Validation report returned by generate/validate (BlueprintCodeValidator). */
+export interface CodeValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  syntax_valid: boolean
+  structure_valid: boolean
+  lint_clean: boolean
+}
+
+/** POST /agent-creator/generate/ request body (name/description/instructions required). */
+export interface GenerateAgentRequest {
+  name: string
+  description: string
+  instructions: string
+  personality?: string
+  expertise?: string[]
+  communication_style?: string
+  tags?: string[]
+}
+
+export interface GenerateAgentResponse {
+  success: boolean
+  code: string
+  validation: CodeValidationResult
+}
+
+export interface ValidateAgentResponse {
+  success: boolean
+  validation: CodeValidationResult
+}
+
+export async function generateAgentCode(
+  spec: GenerateAgentRequest,
+): Promise<GenerateAgentResponse> {
+  await ensureCsrfCookie()
+  return apiPost<GenerateAgentResponse>('/agent-creator/generate/', spec)
+}
+
+export async function validateAgentCode(
+  code: string,
+): Promise<ValidateAgentResponse> {
+  await ensureCsrfCookie()
+  return apiPost<ValidateAgentResponse>('/agent-creator/validate/', { code })
+}
+
+// ---------------------------------------------------------------------------
+// Custom blueprints CRUD (/v1/blueprints/custom/, swarm/views/api_views.py)
+// ---------------------------------------------------------------------------
+
+export interface CustomBlueprint {
+  id: string
+  name: string
+  description: string
+  category: string
+  tags: string[]
+  requirements: string
+  code: string
+  required_mcp_servers: string[]
+  env_vars: string[]
+}
+
+export interface CreateCustomBlueprintRequest {
+  name: string
+  description?: string
+  code?: string
+  category?: string
+  tags?: string[]
+}
+
+export function fetchCustomBlueprints(): Promise<ListResponse<CustomBlueprint>> {
+  return apiGet<ListResponse<CustomBlueprint>>('/v1/blueprints/custom/')
+}
+
+export function createCustomBlueprint(
+  blueprint: CreateCustomBlueprintRequest,
+): Promise<CustomBlueprint> {
+  return apiPost<CustomBlueprint>('/v1/blueprints/custom/', blueprint)
+}
+
+export function deleteCustomBlueprint(blueprintId: string): Promise<void> {
+  return apiDelete(`/v1/blueprints/custom/${encodeURIComponent(blueprintId)}/`)
+}
+
+// ---------------------------------------------------------------------------
+// Server settings (read-only; swarm/views/settings_views.py)
+// ---------------------------------------------------------------------------
+
+/** One entry inside a settings group (SettingsManager.collect_all_settings). */
+export interface ServerSettingEntry {
+  value: unknown
+  env_var: string | null
+  type: string
+  description: string
+  category: string
+  sensitive: boolean
+}
+
+export interface ServerSettingsGroup {
+  title: string
+  description: string
+  icon: string
+  settings: Record<string, ServerSettingEntry>
+}
+
+/** GET /settings/api/ */
+export interface ServerSettingsResponse {
+  success: boolean
+  settings: Record<string, ServerSettingsGroup>
+}
+
+/** GET /settings/environment/ */
+export interface EnvironmentVariablesResponse {
+  success: boolean
+  environment_variables: Record<string, string>
+  count: number
+}
+
+export function fetchServerSettings(): Promise<ServerSettingsResponse> {
+  return apiGet<ServerSettingsResponse>('/settings/api/')
+}
+
+export function fetchEnvironmentVariables(): Promise<EnvironmentVariablesResponse> {
+  return apiGet<EnvironmentVariablesResponse>('/settings/environment/')
+}

--- a/webui/frontend/src/pages/AgentCreatorPage.tsx
+++ b/webui/frontend/src/pages/AgentCreatorPage.tsx
@@ -1,0 +1,466 @@
+import { FormEvent, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  ConfirmModal,
+  Input,
+  SkeletonCard,
+  Textarea,
+  ToastProvider,
+  useToast,
+} from '../components/DaisyUI';
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  Save,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  Wand2,
+} from 'lucide-react';
+import {
+  createCustomBlueprint,
+  deleteCustomBlueprint,
+  fetchCustomBlueprints,
+  generateAgentCode,
+  validateAgentCode,
+  type CodeValidationResult,
+  type CustomBlueprint,
+} from '../lib/api';
+
+/**
+ * Agent creator page.
+ *
+ * - Generate/validate call the real Django endpoints
+ *   (/agent-creator/generate/ and /agent-creator/validate/,
+ *   swarm/views/agent_creator_views.py); api.ts primes the CSRF cookie first.
+ * - Save posts to /v1/blueprints/custom/ rather than /agent-creator/save/:
+ *   the latter writes loose files under user_blueprints/ with no list/delete
+ *   API, while the custom-blueprint library gives this page a single store
+ *   for save, list and delete. Nothing shown here is fabricated client-side.
+ */
+const AgentCreatorPageContent = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  // Spec form
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [instructions, setInstructions] = useState('');
+  const [personality, setPersonality] = useState('');
+  const [expertise, setExpertise] = useState('');
+  const [communicationStyle, setCommunicationStyle] = useState('');
+
+  // Code editor + last validation report
+  const [code, setCode] = useState('');
+  const [validation, setValidation] = useState<CodeValidationResult | null>(null);
+
+  const [blueprintToDelete, setBlueprintToDelete] = useState<CustomBlueprint | null>(null);
+
+  const customQuery = useQuery({
+    queryKey: ['custom-blueprints'],
+    queryFn: fetchCustomBlueprints,
+  });
+  const customBlueprints: CustomBlueprint[] = customQuery.data?.data ?? [];
+
+  const generateMutation = useMutation({
+    mutationFn: generateAgentCode,
+    onSuccess: (res) => {
+      setCode(res.code);
+      setValidation(res.validation);
+      toast.success('Code generated', 'Review the code below, then save.');
+    },
+    onError: (err) => {
+      toast.error(
+        'Generation failed',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+  });
+
+  const validateMutation = useMutation({
+    mutationFn: validateAgentCode,
+    onSuccess: (res) => {
+      setValidation(res.validation);
+      if (res.validation.valid) {
+        toast.success('Validation passed', 'The blueprint code is valid.');
+      } else {
+        toast.warning('Validation failed', 'See the issues listed below.');
+      }
+    },
+    onError: (err) => {
+      toast.error(
+        'Validation request failed',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: createCustomBlueprint,
+    onSuccess: (saved) => {
+      queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] });
+      toast.success('Agent saved', `Saved as custom blueprint "${saved.id}".`);
+    },
+    onError: (err) => {
+      toast.error(
+        'Save failed',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteCustomBlueprint,
+    onSuccess: (_data, blueprintId) => {
+      queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] });
+      toast.success('Blueprint deleted', `"${blueprintId}" was removed.`);
+    },
+    onError: (err) => {
+      toast.error(
+        'Delete failed',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+    onSettled: () => setBlueprintToDelete(null),
+  });
+
+  const specComplete =
+    name.trim().length > 0 &&
+    description.trim().length > 0 &&
+    instructions.trim().length > 0;
+
+  const handleGenerate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!specComplete || generateMutation.isPending) return;
+    generateMutation.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      instructions: instructions.trim(),
+      ...(personality.trim() ? { personality: personality.trim() } : {}),
+      ...(expertise.trim()
+        ? {
+            expertise: expertise
+              .split(',')
+              .map((item) => item.trim())
+              .filter(Boolean),
+          }
+        : {}),
+      ...(communicationStyle.trim()
+        ? { communication_style: communicationStyle.trim() }
+        : {}),
+    });
+  };
+
+  const handleValidate = () => {
+    if (!code.trim() || validateMutation.isPending) return;
+    validateMutation.mutate(code);
+  };
+
+  const handleSave = () => {
+    if (!specComplete || !code.trim() || saveMutation.isPending) return;
+    saveMutation.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      code,
+      tags: ['custom', 'agent-creator'],
+    });
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold flex items-center gap-2">
+          <Wand2 className="h-8 w-8" />
+          Agent Creator
+        </h1>
+        <p className="text-gray-500 mt-1">
+          Generate a blueprint from a persona spec, validate the Python code
+          server-side, and save it to the custom blueprint library
+          (/v1/blueprints/custom/).
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
+        {/* Spec form */}
+        <Card bordered>
+          <h2 className="card-title flex items-center gap-2">
+            <Sparkles className="h-5 w-5" />
+            Agent specification
+          </h2>
+          <form onSubmit={handleGenerate} className="space-y-3 mt-2">
+            <Input
+              label="Name *"
+              placeholder="e.g. Research Assistant"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={64}
+            />
+            <Input
+              label="Description *"
+              placeholder="What does this agent do?"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+            />
+            <Textarea
+              label="Instructions *"
+              placeholder="System-prompt style instructions for the agent…"
+              rows={4}
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              required
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <Input
+                label="Personality (optional)"
+                placeholder="helpful and professional"
+                value={personality}
+                onChange={(e) => setPersonality(e.target.value)}
+              />
+              <Input
+                label="Communication style (optional)"
+                placeholder="clear and concise"
+                value={communicationStyle}
+                onChange={(e) => setCommunicationStyle(e.target.value)}
+              />
+            </div>
+            <Input
+              label="Expertise (optional, comma-separated)"
+              placeholder="coding, research, writing"
+              value={expertise}
+              onChange={(e) => setExpertise(e.target.value)}
+            />
+            <div className="card-actions justify-end pt-2">
+              <Button
+                type="submit"
+                variant="primary"
+                loading={generateMutation.isPending}
+                disabled={!specComplete || generateMutation.isPending}
+              >
+                <Wand2 className="h-4 w-4 mr-2" />
+                Generate code
+              </Button>
+            </div>
+          </form>
+        </Card>
+
+        {/* Code editor + validation */}
+        <Card bordered>
+          <h2 className="card-title flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5" />
+            Blueprint code
+          </h2>
+          <p className="text-sm text-gray-500">
+            Generated code lands here; you can also paste or edit code by hand
+            before validating and saving.
+          </p>
+          <Textarea
+            aria-label="Blueprint Python code"
+            className="font-mono text-xs leading-snug min-h-72"
+            rows={18}
+            placeholder="# Generate code from a spec, or paste blueprint Python here…"
+            value={code}
+            onChange={(e) => {
+              setCode(e.target.value);
+              // Edits invalidate the previous validation report.
+              setValidation(null);
+            }}
+            spellCheck={false}
+          />
+
+          {validation && (
+            <div className="mt-3 space-y-2">
+              <div className="flex items-center gap-2">
+                {validation.valid ? (
+                  <Badge type="success">
+                    <CheckCircle2 className="h-3 w-3 mr-1" />
+                    valid
+                  </Badge>
+                ) : (
+                  <Badge type="error">
+                    <AlertCircle className="h-3 w-3 mr-1" />
+                    invalid
+                  </Badge>
+                )}
+                <Badge type={validation.syntax_valid ? 'success' : 'error'} size="sm">
+                  syntax
+                </Badge>
+                <Badge type={validation.structure_valid ? 'success' : 'error'} size="sm">
+                  structure
+                </Badge>
+                <Badge type={validation.lint_clean ? 'success' : 'warning'} size="sm">
+                  lint
+                </Badge>
+              </div>
+              {validation.errors.length > 0 && (
+                <Alert type="error" icon={<AlertCircle className="h-5 w-5" />}>
+                  <ul className="list-disc list-inside text-sm">
+                    {validation.errors.map((err) => (
+                      <li key={err}>{err}</li>
+                    ))}
+                  </ul>
+                </Alert>
+              )}
+              {validation.warnings.length > 0 && (
+                <Alert type="warning" icon={<AlertCircle className="h-5 w-5" />}>
+                  <ul className="list-disc list-inside text-sm">
+                    {validation.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </Alert>
+              )}
+            </div>
+          )}
+
+          <div className="card-actions justify-end pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              loading={validateMutation.isPending}
+              disabled={!code.trim() || validateMutation.isPending}
+              onClick={handleValidate}
+            >
+              <ShieldCheck className="h-4 w-4 mr-2" />
+              Validate
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              loading={saveMutation.isPending}
+              disabled={!specComplete || !code.trim() || saveMutation.isPending}
+              onClick={handleSave}
+              title={
+                specComplete
+                  ? undefined
+                  : 'Fill in name, description and instructions first'
+              }
+            >
+              <Save className="h-4 w-4 mr-2" />
+              Save to library
+            </Button>
+          </div>
+        </Card>
+      </div>
+
+      {/* Existing custom blueprints */}
+      <div>
+        <h2 className="text-2xl font-bold flex items-center gap-2 mb-4">
+          <Bot className="h-6 w-6" />
+          Custom blueprints
+        </h2>
+
+        {customQuery.isPending && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        )}
+
+        {customQuery.isError && (
+          <Alert type="error" icon={<AlertCircle className="h-5 w-5" />}>
+            <div className="flex flex-col gap-2">
+              <span className="font-medium">Failed to load custom blueprints</span>
+              <span className="text-sm">
+                {customQuery.error instanceof Error
+                  ? customQuery.error.message
+                  : 'Unknown error'}
+              </span>
+              <div>
+                <Button variant="outline" size="sm" onClick={() => customQuery.refetch()}>
+                  Retry
+                </Button>
+              </div>
+            </div>
+          </Alert>
+        )}
+
+        {!customQuery.isPending && !customQuery.isError && customBlueprints.length === 0 && (
+          <Card bordered className="text-center py-10">
+            <Bot className="h-14 w-14 mx-auto text-gray-400 mb-3" />
+            <h3 className="text-lg font-semibold mb-1">No custom blueprints yet</h3>
+            <p className="text-gray-500 text-sm">
+              Agents saved from this page appear here (stored in the server's
+              blueprint library).
+            </p>
+          </Card>
+        )}
+
+        {!customQuery.isPending && !customQuery.isError && customBlueprints.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {customBlueprints.map((blueprint) => (
+              <Card key={blueprint.id} bordered className="hover:shadow-lg transition-shadow">
+                <div className="card-body">
+                  <div className="flex justify-between items-start gap-2 mb-1">
+                    <h3 className="card-title font-mono text-lg">{blueprint.id}</h3>
+                    <Badge type="info" size="sm">
+                      {blueprint.category}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-gray-500 mb-2">
+                    {blueprint.description || 'No description provided.'}
+                  </p>
+                  {blueprint.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mb-3">
+                      {blueprint.tags.map((tag) => (
+                        <Badge key={tag} type="ghost" size="sm">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  <div className="card-actions justify-end">
+                    <Button
+                      variant="outline"
+                      color="error"
+                      size="sm"
+                      onClick={() => setBlueprintToDelete(blueprint)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Trash2 className="h-4 w-4 mr-1" />
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={blueprintToDelete !== null}
+        onClose={() => setBlueprintToDelete(null)}
+        onConfirm={() => {
+          if (blueprintToDelete && !deleteMutation.isPending) {
+            deleteMutation.mutate(blueprintToDelete.id);
+          }
+        }}
+        title="Delete Custom Blueprint"
+        confirmText="Delete"
+        confirmVariant="error"
+      >
+        <p>
+          Delete custom blueprint{' '}
+          <span className="font-mono font-semibold">{blueprintToDelete?.id}</span>?
+          This removes it from the server's blueprint library.
+        </p>
+      </ConfirmModal>
+    </div>
+  );
+};
+
+const AgentCreatorPage = () => (
+  <ToastProvider>
+    <AgentCreatorPageContent />
+  </ToastProvider>
+);
+
+export default AgentCreatorPage;

--- a/webui/frontend/src/pages/SettingsPage.tsx
+++ b/webui/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,33 @@
 import { useState, type FormEvent } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import { Eye, EyeOff, KeyRound } from 'lucide-react'
-import { Button, Card, Input, useToast } from '../components/DaisyUI'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, Eye, EyeOff, KeyRound, ServerCog, TerminalSquare } from 'lucide-react'
+import { Alert, Button, Card, Input, LoadingSpinner, useToast } from '../components/DaisyUI'
 import { useAuth } from '../lib/AuthContext'
+import {
+  fetchEnvironmentVariables,
+  fetchServerSettings,
+  type ServerSettingsGroup,
+} from '../lib/api'
+
+/**
+ * Client-side masking for secret-looking values, applied on top of the
+ * server-side masking already done by /settings/api/ and
+ * /settings/environment/ (which send '***HIDDEN***' / '***SET***' for
+ * sensitive entries). Any value whose name matches KEY/TOKEN/SECRET/PASSWORD
+ * is reduced to its last 4 characters.
+ */
+const SECRET_NAME_PATTERN = /KEY|TOKEN|SECRET|PASSWORD/i
+const SERVER_MASKS = new Set(['***HIDDEN***', '***SET***', 'Not Set'])
+
+export function formatSettingValue(name: string, value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—'
+  const text = typeof value === 'string' ? value : JSON.stringify(value)
+  if (SERVER_MASKS.has(text)) return text
+  if (SECRET_NAME_PATTERN.test(name)) {
+    return `••••${text.slice(-4)}`
+  }
+  return text
+}
 
 const SettingsPage = () => {
   const { token, setToken, clearAuthError } = useAuth()
@@ -111,22 +136,201 @@ const SettingsPage = () => {
           </form>
         </Card>
 
-        {/* Application settings */}
-        <Card bordered>
-          <h2 className="card-title">Application Settings</h2>
-          <div className="form-control w-full max-w-xs">
-            <label className="label">
-              <span className="label-text">Theme</span>
-            </label>
-            <select className="select select-bordered">
-              <option>Light</option>
-              <option>Dark</option>
-              <option>System</option>
-            </select>
-          </div>
-        </Card>
+        {/* Read-only server settings (GET /settings/api/) */}
+        <ServerSettingsCard />
+
+        {/* Read-only environment variables (GET /settings/environment/) */}
+        <EnvironmentVariablesCard />
       </div>
     </div>
+  )
+}
+
+function QueryErrorAlert({
+  what,
+  error,
+  onRetry,
+}: {
+  what: string
+  error: unknown
+  onRetry: () => void
+}) {
+  return (
+    <Alert type="error" icon={<AlertCircle className="h-5 w-5" />}>
+      <div className="flex flex-col gap-2">
+        <span className="font-medium">Failed to load {what}</span>
+        <span className="text-sm">
+          {error instanceof Error ? error.message : 'Unknown error'}
+        </span>
+        <div>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    </Alert>
+  )
+}
+
+function SettingsGroupTable({ group }: { group: ServerSettingsGroup }) {
+  const entries = Object.entries(group.settings)
+
+  return (
+    <details className="collapse collapse-arrow bg-base-200">
+      <summary className="collapse-title font-medium">
+        {group.icon} {group.title}{' '}
+        <span className="text-sm font-normal text-gray-500">
+          ({entries.length} {entries.length === 1 ? 'setting' : 'settings'})
+        </span>
+      </summary>
+      <div className="collapse-content overflow-x-auto">
+        <p className="text-sm text-gray-500 mb-2">{group.description}</p>
+        {entries.length === 0 ? (
+          <p className="text-sm text-gray-400">No settings reported in this group.</p>
+        ) : (
+          <table className="table table-sm">
+            <thead>
+              <tr>
+                <th>Setting</th>
+                <th>Value</th>
+                <th>Env var</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(([settingName, entry]) => (
+                <tr key={settingName}>
+                  <td>
+                    <div className="font-mono text-xs">{settingName}</div>
+                    <div className="text-xs text-gray-500">{entry.description}</div>
+                  </td>
+                  <td className="font-mono text-xs break-all">
+                    {formatSettingValue(settingName, entry.value)}
+                  </td>
+                  <td className="font-mono text-xs">{entry.env_var ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </details>
+  )
+}
+
+function ServerSettingsCard() {
+  const { data, isPending, isError, error, refetch } = useQuery({
+    queryKey: ['server-settings'],
+    queryFn: fetchServerSettings,
+  })
+
+  const groups = Object.entries(data?.settings ?? {})
+
+  return (
+    <Card bordered>
+      <h2 className="card-title flex items-center gap-2">
+        <ServerCog className="h-5 w-5" />
+        Server Settings
+      </h2>
+      <p className="text-sm text-gray-500">
+        Read-only view of the server configuration reported by{' '}
+        <code>/settings/api/</code>. Sensitive values are masked by the server;
+        anything secret-looking is additionally reduced to its last 4
+        characters client-side.
+      </p>
+
+      <div className="mt-3">
+        {isPending && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <LoadingSpinner size="sm" /> Loading server settings…
+          </div>
+        )}
+        {isError && (
+          <QueryErrorAlert
+            what="server settings"
+            error={error}
+            onRetry={() => refetch()}
+          />
+        )}
+        {!isPending && !isError && groups.length === 0 && (
+          <p className="text-sm text-gray-400">
+            The server reported no settings groups.
+          </p>
+        )}
+        {!isPending && !isError && groups.length > 0 && (
+          <div className="space-y-2">
+            {groups.map(([groupKey, group]) => (
+              <SettingsGroupTable key={groupKey} group={group} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+function EnvironmentVariablesCard() {
+  const { data, isPending, isError, error, refetch } = useQuery({
+    queryKey: ['environment-variables'],
+    queryFn: fetchEnvironmentVariables,
+  })
+
+  const variables = Object.entries(data?.environment_variables ?? {})
+
+  return (
+    <Card bordered>
+      <h2 className="card-title flex items-center gap-2">
+        <TerminalSquare className="h-5 w-5" />
+        Environment Variables
+      </h2>
+      <p className="text-sm text-gray-500">
+        Swarm-related environment variables on the server, from{' '}
+        <code>/settings/environment/</code>. The server replaces values of
+        key/token/secret/password variables with <code>***SET***</code>; the
+        same masking rule is applied again client-side.
+      </p>
+
+      <div className="mt-3">
+        {isPending && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <LoadingSpinner size="sm" /> Loading environment variables…
+          </div>
+        )}
+        {isError && (
+          <QueryErrorAlert
+            what="environment variables"
+            error={error}
+            onRetry={() => refetch()}
+          />
+        )}
+        {!isPending && !isError && variables.length === 0 && (
+          <p className="text-sm text-gray-400">
+            No swarm-related environment variables are set on the server.
+          </p>
+        )}
+        {!isPending && !isError && variables.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="table table-sm">
+              <thead>
+                <tr>
+                  <th>Variable</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {variables.map(([key, value]) => (
+                  <tr key={key}>
+                    <td className="font-mono text-xs">{key}</td>
+                    <td className="font-mono text-xs break-all">
+                      {formatSettingValue(key, value)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
   )
 }
 

--- a/webui/frontend/vite.config.ts
+++ b/webui/frontend/vite.config.ts
@@ -19,6 +19,33 @@ export default defineConfig({
                 target: 'http://127.0.0.1:8000',
                 changeOrigin: true,
             },
+            // Agent-creator generate/validate endpoints (Django views). Only
+            // the API subpaths are proxied so a hard refresh on the SPA's
+            // /agent-creator route still serves the SPA.
+            '/agent-creator/generate': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
+            '/agent-creator/validate': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
+            // CSRF cookie priming for the agent-creator POSTs (see api.ts
+            // ensureCsrfCookie); /login/ sets Django's csrftoken cookie.
+            '/login': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
+            // Read-only settings APIs (Django views). Subpaths only, so the
+            // SPA's /settings route keeps working on hard refresh.
+            '/settings/api': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
+            '/settings/environment': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
             '/ws': {
                 target: 'ws://127.0.0.1:8000',
                 ws: true,


### PR DESCRIPTION
## Summary

Implements ROADMAP §3.1 "Agent-creator and settings pages" for the React SPA (`webui/frontend/` only; no backend changes).

### AgentCreatorPage (`/agent-creator`)
- Spec form (name, description, instructions required; optional personality / expertise / communication style) → **POST `/agent-creator/generate/`** fills a code editor and shows the server's validation report (syntax / structure / lint badges, error + warning lists).
- Editable code textarea with **POST `/agent-creator/validate/`** re-validation (edits invalidate the stale report).
- **Save → POST `/v1/blueprints/custom/`** (DRF), then the saved agent appears in the custom-blueprint list below with delete (**DELETE `/v1/blueprints/custom/<id>/`**, confirm modal).
- Honest loading / error / empty states throughout; nothing fabricated client-side (`grep -ri mock src/` is clean).

### SettingsPage expansion (`/settings`)
- API-token card kept as-is; the previous **dead theme `<select>`** (wired to nothing) was removed.
- New read-only **Server Settings** panel from **GET `/settings/api/`** — collapsible per-group tables (value, env var, description).
- New read-only **Environment Variables** panel from **GET `/settings/environment/`**.
- Client-side masking on top of the server's masking: any value whose name matches `KEY|TOKEN|SECRET|PASSWORD` renders as `••••` + last 4 chars (server sentinels `***HIDDEN***` / `***SET***` pass through unchanged).

### CSRF approach (verified against a live dev server)
- `/agent-creator/generate|validate/` are plain Django POST views behind `CsrfViewMiddleware` — they 403 without cookie+header. The SPA primes the `csrftoken` cookie via a cheap `GET /login/` (confirmed it sets the cookie) and the existing fetch wrapper already attaches `X-CSRFToken`; round-trip confirmed end-to-end (generate → validate → save → list → delete all 2xx).
- **Save deliberately uses `POST /v1/blueprints/custom/` instead of `/agent-creator/save/`.** Tradeoff: `/agent-creator/save/` writes loose files under `user_blueprints/` with no list/delete API, so saved agents would never appear in the page's list; the DRF custom-blueprint library gives a coherent save/list/delete story against one store and is CSRF-free for bearer-token/anonymous clients. Documented in the page header comment.

### Shapes verified (live server + source)
- `GenerateAgentResponse { success, code, validation }`, `validation` per `BlueprintCodeValidator` (`src/swarm/views/agent_creator_views.py`)
- `CustomBlueprint { id, name, description, category, tags, requirements, code, required_mcp_servers, env_vars }` (`src/swarm/views/api_views.py`)
- `/settings/api/` group → `{ title, description, icon, settings: { NAME: { value, env_var, type, description, category, sensitive } } }`; `/settings/environment/` → `{ environment_variables, count }` (`src/swarm/views/settings_views.py`)

### Infra
- Routes + desktop/mobile nav entries in `App.tsx`.
- Vite dev-proxy entries for the Django **subpaths only** (`/agent-creator/generate|validate`, `/settings/api|environment`, `/login`) so hard refresh on the SPA's `/agent-creator` and `/settings` routes still serves the SPA.

## Gates
- `npm run type-check` ✅ and `npm run build` ✅ (node 22, fresh `npm ci`)
- `grep -ri mock src/` → no matches ✅
- No backend files modified (pytest untouched-skip per task) ✅

Note: the ROADMAP §3.1 checkbox was intentionally left for the maintainer to tick on merge (this PR owns `webui/frontend/` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)