### PR TITLE
feat(ux): chat layout, settings stats header, landing teams stat + unified quick actions

### DIFF
--- a/src/swarm/templates/settings_dashboard.html
+++ b/src/swarm/templates/settings_dashboard.html
@@ -2,46 +2,46 @@
 {% load static %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-8">
+<div class="container py-4">
   <!-- Header Section -->
-  <div class="mb-8">
-    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+  <div class="dashboard-header-card mb-4">
+    <div class="dashboard-header-top">
       <div>
-        <h1 class="text-3xl font-bold mb-2">⚙️ Settings Dashboard</h1>
-        <p class="text-gray-600">Comprehensive configuration management for Open Swarm</p>
+        <h1 class="dashboard-title">⚙️ Settings Dashboard</h1>
+        <p class="dashboard-subtitle">Comprehensive configuration management for Open Swarm</p>
       </div>
-      <div class="flex gap-4">
-        <div class="stats shadow bg-base-200">
-          <div class="stat">
-            <div class="stat-value text-primary">{{ stats.total }}</div>
-            <div class="stat-title">Total Settings</div>
-          </div>
-          <div class="stat">
-            <div class="stat-value text-secondary">{{ stats.configured }}</div>
-            <div class="stat-title">Configured</div>
-          </div>
-          <div class="stat">
-            <div class="stat-value text-accent">{{ stats.completion_rate }}%</div>
-            <div class="stat-title">Complete</div>
-          </div>
+      <div class="settings-stats">
+        <div class="stat-card">
+          <div class="stat-number">{{ stats.total }}</div>
+          <div class="stat-label">Total Settings</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">{{ stats.configured }}</div>
+          <div class="stat-label">Configured</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">{{ stats.completion_rate }}%</div>
+          <div class="stat-label">Complete</div>
         </div>
       </div>
     </div>
-    
+
     <!-- Progress Bar -->
-    <div class="mt-6">
-      <progress class="progress progress-primary w-full" value="{{ stats.completion_rate }}" max="100"></progress>
-      <div class="text-sm text-gray-500 mt-2">Configuration Progress: {{ stats.configured }}/{{ stats.total }} settings configured</div>
+    <div class="configuration-progress">
+      <div class="config-progress-track" role="progressbar" aria-valuenow="{{ stats.completion_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="Configuration progress">
+        <div class="config-progress-fill" style="width: {{ stats.completion_rate }}%"></div>
+      </div>
+      <div class="progress-text">Configuration Progress: {{ stats.configured }}/{{ stats.total }} settings configured</div>
     </div>
   </div>
 
   <!-- Quick Actions -->
-  <div class="mb-8">
-    <div class="flex gap-4">
+  <div class="mb-4">
+    <div class="d-flex flex-wrap gap-2">
       <button class="btn btn-primary" onclick="exportSettings()">
         <i class="fas fa-download"></i> Export Settings
       </button>
-      <button class="btn btn-outline btn-secondary" onclick="refreshSettings()">
+      <button class="btn btn-outline-secondary" onclick="refreshSettings()">
         <i class="fas fa-sync"></i> Refresh
       </button>
       <button class="btn btn-outline-info" onclick="viewEnvironment()">
@@ -220,12 +220,20 @@
   padding-bottom: 2rem;
 }
 
-.dashboard-header {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  padding: 2rem 0;
-  margin-bottom: 2rem;
+.dashboard-header-card {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 15px;
+  padding: 2rem;
   color: white;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.dashboard-header-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
 }
 
 .dashboard-title {
@@ -237,6 +245,7 @@
 .dashboard-subtitle {
   font-size: 1.1rem;
   opacity: 0.9;
+  margin-bottom: 0;
 }
 
 .settings-stats {
@@ -249,41 +258,43 @@
   background: rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
   border-radius: 10px;
-  padding: 1rem;
+  padding: 1rem 1.25rem;
   text-align: center;
-  min-width: 80px;
+  min-width: 110px;
 }
 
 .stat-number {
-  font-size: 1.5rem;
+  font-size: 1.75rem;
   font-weight: 700;
   color: white;
+  line-height: 1.2;
 }
 
 .stat-label {
   font-size: 0.8rem;
-  opacity: 0.8;
+  opacity: 0.85;
+  white-space: nowrap;
 }
 
 .configuration-progress {
   margin-top: 1.5rem;
 }
 
-.progress-bar {
-  background: rgba(255, 255, 255, 0.2);
+.config-progress-track {
+  background: rgba(255, 255, 255, 0.25);
   border-radius: 10px;
-  height: 8px;
+  height: 10px;
   overflow: hidden;
 }
 
-.progress-fill {
+.config-progress-fill {
   background: linear-gradient(90deg, #28a745, #20c997);
   height: 100%;
+  border-radius: 10px;
   transition: width 0.3s ease;
 }
 
 .progress-text {
-  text-align: center;
   margin-top: 0.5rem;
   font-size: 0.9rem;
   opacity: 0.9;
@@ -536,10 +547,14 @@
   .dashboard-title {
     font-size: 2rem;
   }
-  
+
+  .dashboard-header-card {
+    padding: 1.5rem;
+  }
+
   .settings-stats {
     justify-content: center;
-    margin-top: 1rem;
+    flex-wrap: wrap;
   }
   
   .quick-actions {

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react'
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Home, Settings, Bot, Book, Users, PlusCircle, MessageSquare, ShieldAlert, Wand2, X, Sun, Moon } from 'lucide-react'
-import { Button, Card, Alert, Badge, LoadingSpinner, ToastProvider } from './components/DaisyUI'
+import { Card, Alert, Badge, LoadingSpinner, ToastProvider } from './components/DaisyUI'
 import TeamsPage from './pages/TeamsPage'
 import BlueprintsPage from './pages/BlueprintsPage'
 import ChatPage from './pages/ChatPage'
 import SettingsPage from './pages/SettingsPage'
 import AgentCreatorPage from './pages/AgentCreatorPage'
-import { fetchBlueprints, fetchModels } from './lib/api'
+import { fetchBlueprints, fetchModels, fetchTeams } from './lib/api'
 import { AuthProvider, useAuth } from './lib/AuthContext'
 
 const THEME_STORAGE_KEY = 'swarm_theme'
@@ -171,9 +171,12 @@ function StatValue({
 function Dashboard() {
   const blueprintsQuery = useQuery({ queryKey: ['blueprints'], queryFn: fetchBlueprints })
   const modelsQuery = useQuery({ queryKey: ['models'], queryFn: fetchModels })
+  const teamsQuery = useQuery({ queryKey: ['teams'], queryFn: fetchTeams })
 
-  const apiOnline = blueprintsQuery.isSuccess || modelsQuery.isSuccess
-  const apiChecking = blueprintsQuery.isPending && modelsQuery.isPending
+  const apiOnline =
+    blueprintsQuery.isSuccess || modelsQuery.isSuccess || teamsQuery.isSuccess
+  const apiChecking =
+    blueprintsQuery.isPending && modelsQuery.isPending && teamsQuery.isPending
 
   return (
     <div className="space-y-6">
@@ -184,7 +187,7 @@ function Dashboard() {
       </Alert>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Card compact bordered>
           <div className="stat">
             <div className="stat-title">Blueprints</div>
@@ -212,27 +215,41 @@ function Dashboard() {
             <div className="stat-desc">From /v1/models/</div>
           </div>
         </Card>
+
+        <Card compact bordered>
+          <div className="stat">
+            <div className="stat-title">Teams</div>
+            <div className="stat-value text-primary">
+              <StatValue
+                isPending={teamsQuery.isPending}
+                isError={teamsQuery.isError}
+                value={teamsQuery.data?.data.length}
+              />
+            </div>
+            <div className="stat-desc">From /v1/teams/</div>
+          </div>
+        </Card>
       </div>
 
       {/* Quick Actions */}
       <Card title="Quick Actions" bordered>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Button variant="primary" size="md" className="w-full">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <Link to="/teams" className="btn btn-primary w-full">
             <PlusCircle className="h-5 w-5 mr-2" />
             New Team
-          </Button>
-          <Button variant="secondary" size="md" className="w-full">
+          </Link>
+          <Link to="/blueprints" className="btn btn-outline w-full">
             <Book className="h-5 w-5 mr-2" />
             Browse Blueprints
-          </Button>
-          <Button variant="accent" size="md" className="w-full">
-            <Users className="h-5 w-5 mr-2" />
-            Team Manager
-          </Button>
-          <Button variant="info" size="md" className="w-full">
+          </Link>
+          <Link to="/chat" className="btn btn-outline w-full">
+            <MessageSquare className="h-5 w-5 mr-2" />
+            Open Chat
+          </Link>
+          <Link to="/settings" className="btn btn-outline w-full">
             <Settings className="h-5 w-5 mr-2" />
             Configure
-          </Button>
+          </Link>
         </div>
       </Card>
 

--- a/webui/frontend/src/components/DaisyUI/Card.tsx
+++ b/webui/frontend/src/components/DaisyUI/Card.tsx
@@ -30,7 +30,9 @@ export const Card = ({
   // Build class list
   const classes = [
     'card',
-    bordered ? 'card-bordered' : '',
+    // daisyUI 5 renamed `card-bordered` to `card-border`; keep an explicit
+    // Tailwind border as well so the outline is never theme-dependent.
+    bordered ? 'card-border border border-base-300' : '',
     compact ? 'card-compact' : '',
     normal ? 'card-normal' : '',
     side ? 'card-side' : '',

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, MessageSquare, RefreshCw, Send } from 'lucide-react'
+import { AlertCircle, Info, MessageSquare, RefreshCw, Send } from 'lucide-react'
 import {
   Alert,
   Badge,
   Button,
-  Card,
   LoadingDots,
   LoadingSpinner,
-  SmartSelect,
 } from '../components/DaisyUI'
 import { fetchBlueprints, isAuthError } from '../lib/api'
 import {
@@ -146,30 +144,27 @@ const ChatPage = () => {
   const isStreaming = messages.some((m) => m.streaming)
 
   return (
-    <div className="container mx-auto px-4 py-8 space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold flex items-center gap-2 mb-2">
-            <MessageSquare className="h-8 w-8" />
-            Chat
-          </h1>
-          <p className="text-gray-500">
-            Live chat over the backend websocket (/ws/ai-demo/…)
-          </p>
-        </div>
-        <ConnectionBadge status={status} />
-      </div>
+    <div className="container mx-auto flex h-[calc(100vh-9rem)] min-h-[28rem] flex-col gap-4 px-4 py-6">
+      {/* Header: title + blueprint selector + connection status */}
+      <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+        <h1 className="text-3xl font-bold flex items-center gap-2">
+          <MessageSquare className="h-8 w-8" />
+          Chat
+        </h1>
 
-      {/* Blueprint selector (from /v1/blueprints/) */}
-      <Card bordered compact>
-        <div className="max-w-md">
+        {/* Blueprint selector (from /v1/blueprints/) */}
+        <div className="flex flex-1 flex-wrap items-end justify-end gap-4">
           {blueprintsQuery.isPending ? (
             <div className="flex items-center gap-2 py-2">
               <LoadingSpinner size="sm" />
               <span className="text-sm">Loading blueprints…</span>
             </div>
           ) : blueprintsQuery.isError ? (
-            <Alert type="warning" icon={<AlertCircle className="h-5 w-5" />}>
+            <Alert
+              type="warning"
+              icon={<AlertCircle className="h-5 w-5" />}
+              className="max-w-md py-2"
+            >
               <span className="text-sm">
                 Could not load blueprints
                 {isAuthError(blueprintsQuery.error) ? (
@@ -188,24 +183,43 @@ const ChatPage = () => {
               </span>
             </Alert>
           ) : (
-            <SmartSelect
-              label="Blueprint"
-              placeholder="Select a blueprint"
-              value={selectedBlueprint}
-              onChange={(e) => setSelectedBlueprint(e.target.value)}
-              options={blueprints.map((bp) => ({
-                value: bp.id,
-                label: bp.name || bp.id,
-              }))}
-            />
+            <label className="form-control w-full max-w-xs">
+              <div className="mb-1 flex items-center gap-1.5">
+                <span className="label-text text-sm font-medium">
+                  Blueprint
+                </span>
+                <span
+                  className="tooltip tooltip-bottom before:max-w-[18rem] before:whitespace-normal"
+                  data-tip="The current websocket protocol does not take a blueprint parameter — replies come from the server-configured model."
+                >
+                  <Info
+                    className="h-3.5 w-3.5 opacity-60"
+                    aria-label="Blueprint selection note"
+                  />
+                </span>
+              </div>
+              <select
+                className="select select-bordered select-sm w-full border border-base-300"
+                value={selectedBlueprint}
+                onChange={(e) => setSelectedBlueprint(e.target.value)}
+                aria-label="Blueprint"
+              >
+                <option value="" disabled>
+                  Select a blueprint
+                </option>
+                {blueprints.map((bp) => (
+                  <option key={bp.id} value={bp.id}>
+                    {bp.name || bp.id}
+                  </option>
+                ))}
+              </select>
+            </label>
           )}
-          <p className="text-xs text-gray-500 mt-2">
-            Note: the current websocket protocol does not take a blueprint
-            parameter — replies come from the server-configured model. The
-            selection here does not change the websocket conversation yet.
-          </p>
+          <div className="pb-1">
+            <ConnectionBadge status={status} />
+          </div>
         </div>
-      </Card>
+      </div>
 
       {/* Fallback when the websocket is unavailable */}
       {(status === 'failed' || status === 'closed') && (
@@ -231,19 +245,31 @@ const ChatPage = () => {
         </Alert>
       )}
 
-      {/* Message list */}
-      <Card bordered>
+      {/* Conversation: scrollable message list + composer pinned at bottom */}
+      <div className="card flex min-h-0 flex-1 flex-col overflow-hidden border border-base-300 bg-base-100">
         <div
-          className="h-96 overflow-y-auto space-y-1 pr-2"
+          className="min-h-0 flex-1 space-y-1 overflow-y-auto p-4"
           aria-live="polite"
         >
           {messages.length === 0 ? (
-            <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-              {status === 'open'
-                ? 'Connected. Send a message to start the conversation.'
-                : status === 'connecting'
-                  ? 'Connecting to the chat websocket…'
-                  : 'No messages — the websocket is not connected.'}
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+              <MessageSquare className="h-10 w-10 opacity-20" />
+              <div>
+                <p className="font-medium text-base-content/70">
+                  {status === 'open'
+                    ? 'Connected and ready'
+                    : status === 'connecting'
+                      ? 'Connecting to the chat websocket…'
+                      : 'Websocket not connected'}
+                </p>
+                <p className="text-sm text-base-content/50">
+                  {status === 'open'
+                    ? 'Send a message below to start the conversation.'
+                    : status === 'connecting'
+                      ? 'Hang tight — this usually takes a moment.'
+                      : 'No messages yet — reconnect to start chatting.'}
+                </p>
+              </div>
             </div>
           ) : (
             messages.map((message) => (
@@ -272,32 +298,35 @@ const ChatPage = () => {
           )}
           <div ref={listEndRef} />
         </div>
-      </Card>
 
-      {/* Input */}
-      <form onSubmit={handleSend} className="flex gap-2">
-        <input
-          type="text"
-          className="input input-bordered flex-1"
-          placeholder={
-            status === 'open'
-              ? 'Type a message…'
-              : 'Websocket not connected — sending is disabled'
-          }
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          disabled={status !== 'open'}
-          aria-label="Chat message"
-        />
-        <Button type="submit" variant="primary" disabled={!canSend}>
-          {isStreaming ? (
-            <LoadingSpinner size="sm" className="mr-1" />
-          ) : (
-            <Send className="h-4 w-4 mr-1" />
-          )}
-          Send
-        </Button>
-      </form>
+        {/* Composer */}
+        <form
+          onSubmit={handleSend}
+          className="flex gap-2 border-t border-base-300 p-3"
+        >
+          <input
+            type="text"
+            className="input input-bordered input-sm h-10 flex-1"
+            placeholder={
+              status === 'open'
+                ? 'Type a message…'
+                : 'Websocket not connected — sending is disabled'
+            }
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            disabled={status !== 'open'}
+            aria-label="Chat message"
+          />
+          <Button type="submit" variant="primary" disabled={!canSend}>
+            {isStreaming ? (
+              <LoadingSpinner size="sm" className="mr-1" />
+            ) : (
+              <Send className="h-4 w-4 mr-1" />
+            )}
+            Send
+          </Button>
+        </form>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

UX round 2 — three targeted improvements, all verified with Playwright screenshots against a live dev server.

### 1. SPA Chat page composition (`webui/frontend/src/pages/ChatPage.tsx`)
- Blueprint select now has proper label spacing (form-control with an explicit gap) and renders as `select select-bordered select-sm` with a visible `border-base-300` outline.
- The 3-line websocket protocol note no longer dominates the header — demoted to a lucide `Info` icon with a DaisyUI tooltip next to the Blueprint label.
- The dead space is gone: the conversation is a `card border border-base-300` that fills the available viewport height (`h-[calc(100vh-9rem)]` flex column) with a scrollable message list, the composer pinned at the bottom of the card, and a centered friendly empty state.
- All websocket logic/state handling is untouched.

### 2. Django Settings Dashboard header (`src/swarm/templates/settings_dashboard.html`)
- The old header used DaisyUI `stats`/`progress` classes that don't exist on Bootstrap-based Django pages, so it rendered as a cramped unstyled stack ("63 / Total Settings / 61 / Configured / 91% / Complete").
- Rebuilt as a gradient header card (reusing the page's own custom CSS palette) with three horizontal stat tiles — Total Settings, Configured, Complete % — and a real CSS progress bar (`role="progressbar"` + width from `stats.completion_rate`) with a progress caption.
- Quick-action buttons converted to valid Bootstrap classes (`d-flex gap-2`, `btn-outline-secondary`).
- No DaisyUI imported into Django pages.

### 3. SPA landing stats + quick actions (`webui/frontend/src/App.tsx`)
- Third real stat card **Teams** backed by `GET /v1/teams/` via the existing `fetchTeams`, with the same `StatValue` loading/error treatment; stats grid is now `md:grid-cols-3` (no empty half-row).
- Quick Actions unified: one `btn-primary` (New Team) + three `btn-outline` buttons with identical icon sizing, in `grid-cols-2 lg:grid-cols-4` — and they are now real `Link`s to `/teams`, `/blueprints`, `/chat`, `/settings` instead of dead buttons.
- Bonus fix this surfaced: `Card bordered` emitted `card-bordered`, which daisyUI 5 removed — bordered cards were invisible app-wide. `Card.tsx` now emits `card-border border border-base-300`.

## Verification
- `npm run type-check` + `npm run build` green (CSS bundle 103 kB, JS 258 kB).
- `uv sync --all-extras` + `uv run pytest tests/views -q` → 144 passed.
- Playwright (chromium, 1280x800, logged in as a throwaway superuser so the chat websocket connects) against `manage.py runserver 8437` with a fresh build:
  - **/chat** — bordered compact select with spaced label, info-icon tooltip showing the protocol note, full-height bordered conversation card with pinned composer, "Connected" badge.
  - **/settings/** (Django) — gradient header with three stat tiles (69 / 63 / 91%) and a green progress bar at 91%.
  - **/** — three bordered stat cards (Blueprints 14, Models 14, Teams 0 — all live API values) and the unified quick-actions row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)