### PR TITLE
test: CI golden-journey visual-regression suite (kills the 'green build, unstyled UI' bug class)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,66 @@
+name: Visual Regression
+
+# Golden-journey browser suite (tests/e2e_visual). Exists because a green
+# build has shipped an unstyled UI twice (Tailwind v4 emitting a 2kB CSS
+# bundle; DaisyUI 5 removing `card-bordered`). Unit tests can't see computed
+# styles, so this job builds the real frontend, boots the real dev server,
+# and asserts on what Chromium actually renders.
+#
+# Kept separate from python-pytest.yml so the unit-test matrix stays fast and
+# does not need browsers or a frontend build.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  golden-journey:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: webui/frontend/package-lock.json
+
+      - name: Build frontend (webui/frontend/dist)
+        working-directory: webui/frontend
+        run: |
+          npm ci
+          npm run build
+          # Fail loudly here too if the bundle is suspiciously small.
+          ls -l dist/assets/
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync --all-extras
+
+      - name: Install Playwright Chromium
+        run: uv run playwright install chromium --with-deps
+
+      - name: Run golden-journey visual suite
+        run: uv run pytest tests/e2e_visual -q
+        env:
+          RUN_E2E_VISUAL: "1"
+          DJANGO_ALLOW_ASYNC_UNSAFE: "true"
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-visual-failure-screenshots
+          path: tests/e2e_visual/artifacts/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ test = [
     "respx>=0.20.0",
     "psutil>=5.9.0",
     "pytest-timeout>=2.1.0",
+    # Browser automation for the opt-in golden-journey suite (tests/e2e_visual,
+    # gated behind RUN_E2E_VISUAL=1; see .github/workflows/visual-regression.yml).
+    "playwright>=1.49.0",
 ]
 docs = [
     "Sphinx>=7.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 markers =
     integration: integration test
     timeout: test with timeout
+    e2e_visual: browser-driven golden-journey visual checks (opt-in via RUN_E2E_VISUAL=1; see tests/e2e_visual/)
 
 DJANGO_SETTINGS_MODULE = swarm.settings
 python_files = tests.py test_*.py *_tests.py

--- a/tests/e2e_visual/.gitignore
+++ b/tests/e2e_visual/.gitignore
@@ -1,0 +1,2 @@
+# Failure screenshots captured by conftest.py (uploaded as CI artifacts).
+artifacts/

--- a/tests/e2e_visual/conftest.py
+++ b/tests/e2e_visual/conftest.py
@@ -1,0 +1,204 @@
+"""Fixtures for the opt-in golden-journey visual-regression suite.
+
+These tests exist because a "green build" has shipped an unstyled UI twice:
+
+1. Tailwind v4 misconfiguration emitted a ~2kB CSS file (no utilities), and
+2. DaisyUI 5 renamed ``card-bordered`` to ``card-border``, silently dropping
+   card borders.
+
+Unit tests and HTTP-status smoke tests cannot catch either class of bug, so
+this suite drives a real Chromium against a real dev server (daphne-aware
+``runserver``, so websockets work) and asserts on *computed styles*.
+
+The whole package is skipped unless ``RUN_E2E_VISUAL=1`` to keep the default
+suite fast and free of browser/node dependencies. CI runs it from
+``.github/workflows/visual-regression.yml`` after building the frontend.
+
+Server-start pattern mirrors ``scripts/capture_user_journey.py`` (build-aware
+dev server with DJANGO_DEBUG=true / ENABLE_WEBUI=true, migrations, a
+throwaway superuser, dedicated port) but is factored as fixtures here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FRONTEND_DIST = REPO_ROOT / "webui" / "frontend" / "dist"
+ARTIFACT_DIR = Path(__file__).resolve().parent / "artifacts"
+
+PORT = 8326  # dedicated; journey-capture script owns 8321
+BASE_URL = f"http://127.0.0.1:{PORT}"
+VIEWPORT = {"width": 1280, "height": 800}
+
+# Throwaway credentials (local-only; the e2e database is a tempfile).
+ADMIN_USER = "e2e-visual-admin"
+ADMIN_PASS = "e2e-visual-pass-8326"
+
+ENABLED = os.environ.get("RUN_E2E_VISUAL") == "1"
+SKIP_REASON = (
+    "e2e visual suite is opt-in: set RUN_E2E_VISUAL=1 (needs a built "
+    "webui/frontend/dist and `playwright install chromium`)"
+)
+_HERE = Path(__file__).resolve().parent
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip everything in this directory unless explicitly enabled, so the
+    default suite stays fast and free of browser/node dependencies."""
+    if ENABLED:
+        return
+    skip = pytest.mark.skip(reason=SKIP_REASON)
+    for item in items:
+        if Path(str(item.fspath)).resolve().is_relative_to(_HERE):
+            item.add_marker(skip)
+
+
+def _server_env(db_path: str) -> dict[str, str]:
+    return {
+        **os.environ,
+        "DJANGO_DEBUG": "true",   # dev mode; relaxes SECRET_KEY requirement
+        "ENABLE_WEBUI": "true",   # /teams/ et al. 404 without this
+        "DJANGO_DB_NAME": db_path,
+    }
+
+
+@pytest.fixture(scope="session")
+def frontend_dist() -> Path:
+    """Fail fast (not skip!) if the SPA bundle is missing.
+
+    Skipping here would recreate the very failure mode this suite guards
+    against: a green run with no styled UI ever exercised.
+    """
+    index = FRONTEND_DIST / "index.html"
+    if not index.exists():
+        pytest.fail(
+            f"{index} not found. Build the frontend first:\n"
+            "  cd webui/frontend && npm ci && npm run build"
+        )
+    return FRONTEND_DIST
+
+
+@pytest.fixture(scope="session")
+def live_server_url(frontend_dist: Path) -> str:
+    """Migrate a throwaway sqlite DB, create a superuser, and run the
+    daphne-aware dev server (serves the SPA fallback + websockets)."""
+    with tempfile.TemporaryDirectory(prefix="e2e-visual-db-") as tmp:
+        env = _server_env(str(Path(tmp) / "db.sqlite3"))
+        manage = [sys.executable, str(REPO_ROOT / "manage.py")]
+        subprocess.run(
+            [*manage, "migrate", "-v", "0"],
+            cwd=REPO_ROOT, env=env, check=True, capture_output=True,
+        )
+        superuser_code = (
+            "from django.contrib.auth import get_user_model; "
+            "U = get_user_model(); "
+            f"u, _ = U.objects.get_or_create(username='{ADMIN_USER}'); "
+            "u.is_staff = True; u.is_superuser = True; "
+            f"u.set_password('{ADMIN_PASS}'); u.save()"
+        )
+        subprocess.run(
+            [*manage, "shell", "-c", superuser_code],
+            cwd=REPO_ROOT, env=env, check=True, capture_output=True,
+        )
+        proc = subprocess.Popen(
+            [*manage, "runserver", str(PORT), "--noreload"],
+            cwd=REPO_ROOT, env=env,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            deadline = time.time() + 90
+            while True:
+                if proc.poll() is not None:
+                    raise RuntimeError(
+                        f"dev server exited early (rc={proc.returncode})"
+                    )
+                try:
+                    urllib.request.urlopen(BASE_URL + "/v1/models", timeout=2)
+                    break
+                except Exception:
+                    if time.time() > deadline:
+                        proc.terminate()
+                        raise RuntimeError(
+                            "dev server not ready within 90s"
+                        ) from None
+                    time.sleep(0.5)
+            yield BASE_URL
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+@pytest.fixture(scope="session")
+def browser():
+    # Imported lazily so the default (skipped) run never needs playwright
+    # at collection time.
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        yield browser
+        browser.close()
+
+
+@pytest.fixture(scope="session")
+def auth_state(browser, live_server_url: str, tmp_path_factory) -> Path:
+    """Log in once through the real form and persist the session cookie as a
+    Playwright storage state, so every test gets an authenticated context
+    without repeating the login flow."""
+    state_path = tmp_path_factory.mktemp("e2e-visual-auth") / "state.json"
+    context = browser.new_context(viewport=VIEWPORT)
+    page = context.new_page()
+    page.goto(f"{live_server_url}/accounts/login/", wait_until="domcontentloaded")
+    page.locator("input[name='username'], input[type='text']").first.fill(ADMIN_USER)
+    page.locator("input[name='password'], input[type='password']").first.fill(ADMIN_PASS)
+    page.locator("button[type='submit'], input[type='submit']").first.click()
+    page.wait_for_load_state("networkidle", timeout=15000)
+    assert "login" not in page.url, (
+        f"form login with the throwaway superuser failed; still on {page.url}"
+    )
+    context.storage_state(path=str(state_path))
+    context.close()
+    return state_path
+
+
+@pytest.fixture
+def page(browser, live_server_url: str, auth_state: Path, request):
+    """Authenticated page; captures a screenshot artifact on test failure."""
+    context = browser.new_context(
+        viewport=VIEWPORT, storage_state=str(auth_state)
+    )
+    page = context.new_page()
+    yield page
+    rep = getattr(request.node, "rep_call", None)
+    if rep is not None and rep.failed:
+        ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+        slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", request.node.name)
+        try:
+            page.screenshot(
+                path=str(ARTIFACT_DIR / f"{slug}.png"), full_page=True
+            )
+        except Exception:
+            pass  # never let artifact capture mask the real failure
+    context.close()
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Expose each phase's report on the item so the ``page`` fixture's
+    teardown can tell whether the test body failed."""
+    rep = yield
+    setattr(item, f"rep_{rep.when}", rep)
+    return rep

--- a/tests/e2e_visual/test_golden_journey.py
+++ b/tests/e2e_visual/test_golden_journey.py
@@ -1,0 +1,154 @@
+"""Golden-journey visual assertions (computed styles, not just HTTP 200s).
+
+Each test pins down a real regression class that previously shipped green:
+
+- ``test_landing_page_is_styled``      -> Tailwind v4 emitted a 2kB CSS file
+- ``test_blueprint_cards_have_borders``-> DaisyUI 5 removed ``card-bordered``
+- ``test_teams_navbar_has_no_zero_text_links`` -> white-box navbar links
+- ``test_chat_websocket_connects``     -> ASGI/daphne wiring
+- ``test_dark_mode_toggle``            -> theme CSS actually compiled in
+
+Run locally with::
+
+    cd webui/frontend && npm ci && npm run build && cd ../..
+    uv run playwright install chromium
+    RUN_E2E_VISUAL=1 uv run pytest tests/e2e_visual -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.e2e_visual
+
+TRANSPARENT = ("rgba(0, 0, 0, 0)", "transparent")
+
+# The empty-CSS guard: the healthy bundle is ~100kB; the Tailwind v4
+# misconfiguration shipped ~2kB. Anything under this is utilities-free.
+MIN_CSS_BYTES = 50_000
+
+
+def _computed(page, locator, prop: str) -> str:
+    return locator.evaluate(f"el => getComputedStyle(el)['{prop}']")
+
+
+def test_landing_page_is_styled(page, live_server_url):
+    page.goto(live_server_url + "/", wait_until="networkidle")
+
+    # Browser-default rendering means the stylesheet never applied.
+    font = _computed(page, page.locator("body"), "fontFamily")
+    assert "times" not in font.lower() and font.lower() != "serif", (
+        f"body font-family is the browser serif default ({font!r}); "
+        "the built CSS is not applying"
+    )
+
+    btn = page.locator(".btn-primary").first
+    btn.wait_for(state="visible", timeout=10_000)
+    bg = _computed(page, btn, "backgroundColor")
+    assert bg not in TRANSPARENT, (
+        ".btn-primary has a transparent background; DaisyUI component "
+        "styles are missing from the bundle"
+    )
+
+    # The empty-CSS guard: fetch every stylesheet the page links and demand
+    # a real utilities bundle, not a 2kB stub.
+    hrefs = page.eval_on_selector_all(
+        "link[rel='stylesheet']", "els => els.map(el => el.href)"
+    )
+    assert hrefs, "landing page links no stylesheets at all"
+    sizes = {}
+    for href in hrefs:
+        resp = page.request.get(href)
+        assert resp.ok, f"built CSS {href} returned HTTP {resp.status}"
+        sizes[href] = len(resp.body())
+    assert max(sizes.values()) > MIN_CSS_BYTES, (
+        f"largest linked stylesheet is only {max(sizes.values())} bytes "
+        f"(need > {MIN_CSS_BYTES}); Tailwind emitted an empty bundle. {sizes}"
+    )
+
+
+def test_login_with_throwaway_superuser(browser, live_server_url, auth_state):
+    """Form login succeeded (asserted inside the auth_state fixture) and the
+    persisted session actually authenticates a fresh context."""
+    context = browser.new_context(storage_state=str(auth_state))
+    page = context.new_page()
+    try:
+        page.goto(live_server_url + "/teams/", wait_until="domcontentloaded")
+        assert "login" not in page.url, (
+            "stored session was bounced back to the login page"
+        )
+    finally:
+        context.close()
+
+
+def test_chat_websocket_connects(page, live_server_url):
+    """The Connected badge only renders after ws.onopen fires, so this also
+    guards the ASGI/daphne websocket wiring."""
+    page.goto(live_server_url + "/chat", wait_until="domcontentloaded")
+    badge = page.get_by_text("Connected", exact=True)
+    badge.wait_for(state="visible", timeout=20_000)
+
+
+def test_blueprint_cards_have_borders(page, live_server_url):
+    """The card-bordered guard: DaisyUI 5 renamed ``card-bordered`` to
+    ``card-border``; with the stale class the cards rendered borderless."""
+    page.goto(live_server_url + "/blueprints", wait_until="networkidle")
+    cards = page.locator(".card")
+    cards.first.wait_for(state="visible", timeout=10_000)
+    widths = []
+    for i in range(cards.count()):
+        w = _computed(page, cards.nth(i), "borderTopWidth")
+        widths.append(w)
+        if w.endswith("px") and float(w[:-2]) >= 1:
+            return
+    pytest.fail(
+        f"no .card on /blueprints has a computed border-top-width >= 1px "
+        f"(got {widths}); the bordered-card styling regressed"
+    )
+
+
+def test_teams_navbar_has_no_zero_text_links(page, live_server_url):
+    """The white-box guard: every visible navbar link on the Django-rendered
+    /teams/ page must carry text, not render as an empty box."""
+    page.goto(live_server_url + "/teams/", wait_until="domcontentloaded")
+    assert "login" not in page.url, "/teams/ redirected to login despite auth"
+    links = page.locator("nav a")
+    count = links.count()
+    assert count >= 3, f"expected a populated navbar on /teams/, found {count} links"
+    empty = []
+    for i in range(count):
+        link = links.nth(i)
+        if not link.is_visible():
+            continue
+        if not link.inner_text().strip():
+            empty.append(link.evaluate("el => el.outerHTML"))
+    assert not empty, f"navbar has zero-text nav links: {empty}"
+
+
+def test_dark_mode_toggle(page, live_server_url):
+    """Clicking the toggle must flip the theme attribute AND visibly change
+    the themed background — proving the DaisyUI theme CSS was compiled in.
+
+    Note: this SPA carries ``data-theme`` on the app root <div> (App.tsx),
+    not on documentElement, so assert on the actual attribute carrier.
+    """
+    page.goto(live_server_url + "/", wait_until="networkidle")
+    themed = page.locator("[data-theme]").first
+    themed.wait_for(state="attached", timeout=10_000)
+
+    theme_before = themed.get_attribute("data-theme")
+    bg_before = _computed(page, themed, "backgroundColor")
+
+    page.get_by_label("Toggle dark mode").click()
+    page.wait_for_timeout(250)  # let React re-render + CSS vars resolve
+
+    theme_after = themed.get_attribute("data-theme")
+    bg_after = _computed(page, themed, "backgroundColor")
+
+    assert theme_after != theme_before, (
+        f"data-theme did not change on toggle (still {theme_after!r})"
+    )
+    assert bg_after != bg_before, (
+        f"theme attribute flipped to {theme_after!r} but background stayed "
+        f"{bg_after!r}; the theme CSS is not compiled into the bundle"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1849,6 +1849,7 @@ memory = [
 test = [
     { name = "anyio" },
     { name = "factory-boy" },
+    { name = "playwright" },
     { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1897,6 +1898,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.3.0,<2.0.0" },
     { name = "openai-agents", specifier = ">=0.0.1" },
     { name = "platformdirs", specifier = ">=4.0.0" },
+    { name = "playwright", marker = "extra == 'test'", specifier = ">=1.49.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "psutil", marker = "extra == 'test'", specifier = ">=5.9.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
@@ -2023,6 +2025,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654 },
+]
+
+[[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635 },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327 },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636 },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220 },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856 },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157 },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159 },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981 },
 ]
 
 [[package]]
@@ -2333,6 +2354,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582 },
     { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985 },
     { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715 },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

A green build has shipped an unstyled UI **twice**:

1. A Tailwind v4 misconfiguration emitted a ~2kB CSS bundle (no utilities at all).
2. DaisyUI 5 renamed `card-bordered` to `card-border`, silently dropping every card border.

HTTP-200 smoke tests and unit tests are blind to both. This PR adds a browser-driven golden-journey suite that asserts on **computed styles** rendered by a real Chromium against a real server, so this class of regression fails CI instead of shipping.

## What

### `tests/e2e_visual/` (new)
- `conftest.py` — session fixtures that mirror `scripts/capture_user_journey.py`: tempfile sqlite DB, `migrate`, throwaway superuser, daphne-aware `runserver` on a dedicated port (8326) with `DJANGO_DEBUG=true ENABLE_WEBUI=true`; one form login persisted as Playwright storage state; per-test authenticated contexts; **failure screenshots** captured in fixture teardown (via a `pytest_runtest_makereport` wrapper) to `tests/e2e_visual/artifacts/`.
- `test_golden_journey.py` — six assertions:
  - `/` — body `font-family` is not the browser serif default; `.btn-primary` background is not transparent; every linked stylesheet returns 200 and the largest is **> 50 kB** (the empty-CSS guard; healthy bundle is ~103 kB)
  - login — form login with the throwaway superuser succeeds and the stored session authenticates a fresh context
  - `/chat` — the `Connected` badge appears (only renders after `ws.onopen`, so this also guards the ASGI/daphne websocket wiring)
  - `/blueprints` — at least one `.card` has computed `border-top-width >= 1px` (the card-bordered guard)
  - `/teams/` (Django-rendered) — navbar exists and no visible nav link has zero text (the white-box guard)
  - dark-mode toggle — flips the `data-theme` attribute **and** the computed background color (proves the theme CSS is compiled in; note the SPA carries `data-theme` on the app root div, not `documentElement`, so the assertion targets the actual attribute carrier)

  The suite **fails** (not skips) if `webui/frontend/dist` is missing — skipping there would recreate the silent-green failure mode.

### Gating
Everything is skipped unless `RUN_E2E_VISUAL=1`, so the default `uv run pytest` stays fast, deterministic, and browser-free (shows as 6 skipped; pass count unchanged at 864).

### `.github/workflows/visual-regression.yml` (new)
Separate workflow (keeps the unit-test matrix fast): on PR + push to main — Node 22 + `npm ci` + `npm run build`, setup-uv + `uv sync --all-extras`, `playwright install chromium --with-deps`, `RUN_E2E_VISUAL=1 uv run pytest tests/e2e_visual -q`, and uploads `tests/e2e_visual/artifacts/` as `e2e-visual-failure-screenshots` on failure.

### Supporting edits
- `pytest.ini` — registers the `e2e_visual` marker.
- `pyproject.toml` / `uv.lock` — `playwright>=1.49.0` added to the `[test]` extra (needed so `uv run pytest tests/e2e_visual` works in CI and locally; `uv lock --check` passes).

## Verification (local)

- `RUN_E2E_VISUAL=1 uv run pytest tests/e2e_visual -q` → **6 passed in ~8s** (frontend built, cached Chromium)
- `uv run pytest -q` → **864 passed, 9 skipped** (the 6 new tests skip; pass count unchanged vs. main)
- Failure-screenshot path verified with a temporary intentionally-failing test: a full-page PNG landed in `tests/e2e_visual/artifacts/`
- Workflow YAML parses (`yaml.safe_load`); `uv lock --check` green

## CI caveats (honest)

- `playwright install chromium --with-deps` (the apt system-deps path) could not be exercised locally — browsers were already cached. It is the documented path on `ubuntu-latest`, but the first CI run of this workflow is the real test.
- The workflow pins Python 3.12 (single job, not the 3.10–3.12 matrix) — visual rendering does not vary by Python minor version.
- Local verification ran headless Chromium 1.60; CI will download its own pinned build, so pixel-level differences are possible, but the suite asserts computed styles, not pixels, precisely to stay robust to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)