### PR TITLE
docs(roadmap): record non-streaming test-mode chat bug

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,6 +70,8 @@ Last updated: 2026-06-11 (post PR waves #80–#85; origin reduced to main; Docke
 
 - [x] **ASGI routing for websocket chat** — `swarm/asgi.py` + `routing.py` created; daphne/channels registered (they were declared core deps all along, never wired); 9 full-stack tests; live-verified 101 upgrade with session auth, 403 anonymous/bad-origin (`docs/websocket_chat.md`)
 
+- [ ] **Known issue (found while making the README demo): non-streaming `/v1/chat/completions` returns spinner text in test mode** — `_handle_non_streaming` in `src/swarm/views/chat_views.py` breaks on the first `messages` chunk, so test-mode answers come back as "Generating."; streaming works. Several blueprints (geese, jeeves, stewie, codey, chucks_angels, django_chat, rue_code) error outright via the API in test mode — `zeus` is the only blueprint verified working on both CLI and API surfaces. Fix the chunk handling + add per-blueprint API smoke tests.
+
 ### 2.1 Deprecation shim sunset
 
 The consolidation left 7 import shims emitting `DeprecationWarning`


### PR DESCRIPTION
Found while capturing the README demo: _handle_non_streaming returns spinner text in test mode; several blueprints error via API in test mode (zeus verified working on both surfaces). Tracked for fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)