### PR TITLE
fix(api): non-streaming test-mode answers + per-blueprint API smoke matrix

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Last updated: 2026-06-11 (post PR waves #80–#85; origin reduced to main; Docke
 
 - [x] **ASGI routing for websocket chat** — `swarm/asgi.py` + `routing.py` created; daphne/channels registered (they were declared core deps all along, never wired); 9 full-stack tests; live-verified 101 upgrade with session auth, 403 anonymous/bad-origin (`docs/websocket_chat.md`)
 
-- [ ] **Known issue (found while making the README demo): non-streaming `/v1/chat/completions` returns spinner text in test mode** — `_handle_non_streaming` in `src/swarm/views/chat_views.py` breaks on the first `messages` chunk, so test-mode answers come back as "Generating."; streaming works. Several blueprints (geese, jeeves, stewie, codey, chucks_angels, django_chat, rue_code) error outright via the API in test mode — `zeus` is the only blueprint verified working on both CLI and API surfaces. Fix the chunk handling + add per-blueprint API smoke tests.
+- [x] **Non-streaming `/v1/chat/completions` test-mode bug FIXED** — chunk normalizer consumes the whole generator and returns the final message (was: first spinner chunk). Per-blueprint API smoke matrix added (`tests/api/test_blueprint_api_smoke.py`): 13 blueprints verified answering on BOTH streaming and non-streaming surfaces (was: only zeus). Remaining xfail: `whiskeytango_foxtrot` hangs in test mode (no canned-response path) — fix its run() or demote to examples.
 
 ### 2.1 Deprecation shim sunset
 

--- a/src/swarm/blueprints/chucks_angels/blueprint_chucks_angels.py
+++ b/src/swarm/blueprints/chucks_angels/blueprint_chucks_angels.py
@@ -25,9 +25,12 @@ class ChucksAngelsBlueprint(BlueprintBase): # Inherit from BlueprintBase
     # version: str = "0.1.0"
     # description: str = "A blueprint for coordinating angelic tasks, Chuck Norris style."
 
-    async def run(self, messages: list[dict[str, Any]]) -> AsyncGenerator[dict[str, Any], None]:
+    async def run(self, messages: list[dict[str, Any]], **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:
         """
         The main execution method for the Chuck's Angels blueprint.
+
+        Accepts **kwargs (e.g. ``stream=``) for compatibility with the
+        OpenAI-compatible API layer, which always passes ``stream``.
         """
         self.console.print(f"[bold green]{self.metadata.get('name', 'Chucks Angels Blueprint')} ({self.blueprint_id}) activated![/bold green]")
         self.console.print(f"Received messages: {messages}")

--- a/src/swarm/blueprints/codey/blueprint_codey.py
+++ b/src/swarm/blueprints/codey/blueprint_codey.py
@@ -428,6 +428,9 @@ class CodeyBlueprint(BlueprintBase):
                     emoji='🤖',
                     border='╔'
                 )
+                # Yield a final canned message so API consumers (non-streaming
+                # and streaming) receive real content, not just printed boxes.
+                yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Codey code search complete for: '{instruction}'. Found 10 matches."}]}
                 return
             else:
                 # Semantic Search legacy/test output
@@ -484,6 +487,9 @@ class CodeyBlueprint(BlueprintBase):
                     emoji='🤖',
                     border='╔'
                 )
+                # Yield a final canned message so API consumers (non-streaming
+                # and streaming) receive real content, not just printed boxes.
+                yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Codey semantic search complete for: '{instruction}'. Found 10 matches."}]}
                 return
         search_mode = kwargs.get('search_mode', 'semantic')
         if search_mode in ("semantic", "code"):

--- a/src/swarm/blueprints/django_chat/blueprint_django_chat.py
+++ b/src/swarm/blueprints/django_chat/blueprint_django_chat.py
@@ -183,8 +183,12 @@ class DjangoChatBlueprint(Blueprint):
     def render_prompt(self, _template_name: str, context: dict) -> str:
         return f"User request: {context.get('user_request', '')}\nHistory: {context.get('history', '')}\nAvailable tools: {', '.join(context.get('available_tools', []))}"
 
-    async def run(self, messages: list[dict[str, str]]):
-        """Main execution entry point for the DjangoChat blueprint."""
+    async def run(self, messages: list[dict[str, str]], **kwargs):
+        """Main execution entry point for the DjangoChat blueprint.
+
+        Accepts **kwargs (e.g. ``stream=``) for compatibility with the
+        OpenAI-compatible API layer, which always passes ``stream``.
+        """
         logger.info("DjangoChatBlueprint run method called.")
         instruction = messages[-1].get("content", "") if messages else ""
         ux = BlueprintUXImproved(style="serious")

--- a/src/swarm/blueprints/jeeves/blueprint_jeeves.py
+++ b/src/swarm/blueprints/jeeves/blueprint_jeeves.py
@@ -279,11 +279,13 @@ class JeevesBlueprint(BlueprintBase):
             search_mode = kwargs.get("search_mode")
             if search_mode == 'code':
                 await self.search(instruction, ".")
+                yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Jeeves code search complete for: '{instruction}'."}]}
                 return
             elif search_mode == 'semantic':
                 await self.semantic_search(instruction, ".")
+                yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Jeeves semantic search complete for: '{instruction}'."}]}
                 return
-            
+
             # Print spinner states
             for msg in JeevesSpinner.SPINNER_STATES:
                 print(msg)
@@ -291,6 +293,9 @@ class JeevesBlueprint(BlueprintBase):
             print(JeevesSpinner.LONG_WAIT_MSG)
             # Indicate completion for CLI tests
             print("Jeeves Output")
+            # Yield a final canned message so API consumers (non-streaming and
+            # streaming) receive real content, not just printed spinner frames.
+            yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Jeeves at your service. You said: '{instruction}'"}]}
             return
         # (Continue with existing logic for agent/LLM run)
         # ... existing logic ...

--- a/src/swarm/blueprints/poets/blueprint_poets.py
+++ b/src/swarm/blueprints/poets/blueprint_poets.py
@@ -4,6 +4,7 @@ Poets Blueprint
 Viral docstring update: Operational as of 2025-04-18T10:14:18Z (UTC).
 Self-healing, fileops-enabled, swarm-scalable.
 """
+import asyncio
 import logging
 import os
 import random

--- a/src/swarm/blueprints/rue_code/blueprint_rue_code.py
+++ b/src/swarm/blueprints/rue_code/blueprint_rue_code.py
@@ -310,7 +310,6 @@ class RueCodeBlueprint(BlueprintBase):
         if self._config is None:
             self._config = load_full_configuration(
                 blueprint_class_name=self.__class__.__name__,
-                default_config_path=Path(os.path.dirname(__file__)).parent.parent.parent / 'swarm_config.json',
                 config_path_override=config_path,
                 profile_override=None,
                 cli_config_overrides=None
@@ -340,7 +339,8 @@ class RueCodeBlueprint(BlueprintBase):
     def summary(self, label, count, params):
         return f"{label} ({count} results) for: {params}"
 
-    async def run(self, messages: list[dict[str, str]]):
+    async def run(self, messages: list[dict[str, str]], **kwargs):
+        # **kwargs: the API layer passes options like stream=; accept and ignore.
         logger.info("RueCodeBlueprint run method called.")
         last_user_message = next((m['content'] for m in reversed(messages) if m['role'] == 'user'), None)
         if not last_user_message:

--- a/src/swarm/blueprints/stewie/blueprint_stewie.py
+++ b/src/swarm/blueprints/stewie/blueprint_stewie.py
@@ -211,12 +211,23 @@ class StewieBlueprint(BlueprintBase):
         logger.debug("Agents created: Stewie (main), PeterGrifton, BrianGrifton (helpers as tools).")
         return stewie_agent
 
-    async def run(self, *args, **kwargs):
+    async def run(self, messages: list[dict[str, Any]] | None = None, **kwargs):
+        """Async-generator entry point (OpenAI-compatible API contract).
+
+        Previously this was a plain coroutine that returned the abstract
+        ``super().run(...)`` generator, which broke ``async for`` consumers
+        (the API layer) with "'async for' requires an object with __aiter__".
+        """
         # Patch: Always provide a minimal valid config for tests if missing
         if not self._config:
             self._config = {'llm': {'default': {'model': 'gpt-mock', 'provider': 'openai'}}, 'llm_profile': 'default'}
-        # Existing logic...
-        return super().run(*args, **kwargs)
+        messages = messages or []
+        instruction = messages[-1].get("content", "") if messages else ""
+        if os.environ.get("SWARM_TEST_MODE"):
+            yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] Stewie here. What the deuce do you want with: '{instruction}'?"}]}
+            return
+        async for chunk in self._run_non_interactive(instruction, **kwargs):
+            yield chunk
 
     async def _run_non_interactive(self, instruction: str, **kwargs) -> Any:
         logger.info(f"Running Stewie non-interactively with instruction: '{instruction[:100]}...'")

--- a/src/swarm/blueprints/whinge_surf/blueprint_whinge_surf.py
+++ b/src/swarm/blueprints/whinge_surf/blueprint_whinge_surf.py
@@ -69,9 +69,22 @@ class WhingeSurfBlueprint(BlueprintBase):
         self._load_jobs()
 
     async def run(self, messages: list[dict], **kwargs):
-        """Stub run to satisfy abstract base."""
-        if False:
-            yield {}
+        """Answer over the API surface.
+
+        WhingeSurf is primarily a CLI job manager (!run/!status); over the
+        chat API it responds with usage guidance (canned in test mode).
+        """
+        last = next((m.get("content", "") for m in reversed(messages)
+                     if m.get("role") == "user"), "")
+        if os.environ.get("SWARM_TEST_MODE"):
+            content = f"[TEST-MODE] WhingeSurf here. You said: '{last}'"
+        else:
+            content = (
+                "WhingeSurf manages background subprocess jobs from the CLI: "
+                "use `!run <cmd>` to launch and `!status <job_id>` to poll. "
+                "Run it via `swarm-cli launch whinge_surf` for the full UX."
+            )
+        yield {"messages": [{"role": "assistant", "content": content}]}
 
     def _load_jobs(self):
         if os.path.exists(self.JOBS_FILE):

--- a/src/swarm/views/chat_views.py
+++ b/src/swarm/views/chat_views.py
@@ -60,6 +60,61 @@ except Exception:
     pass
 
 # ==============================================================================
+# Chunk normalization helpers
+# ==============================================================================
+
+def _extract_message_from_chunk(chunk: Any) -> dict[str, Any] | None:
+    """Normalize a single chunk yielded by a blueprint's run() generator.
+
+    Blueprints emit several shapes:
+      - internal dicts: ``{"messages": [{"role", "content"}]}``
+      - OpenAI-like objects: ``{"choices": [{"message"|"delta": {...}}]}``
+      - bare message dicts: ``{"message": {"role", "content"}}`` or
+        top-level ``{"role", "content"}`` (e.g. chucks_angels)
+      - ``AgentInteraction`` dataclasses (``.role``/``.content``/``.final``)
+      - progress side-channel dicts (e.g. ``{"type": "spinner_update", ...}``)
+
+    Returns a ``{"role", "content"}`` dict, or None when the chunk carries no
+    message payload (progress/spinner side-channel chunks).
+    """
+    if chunk is None:
+        return None
+    if not isinstance(chunk, dict):
+        # AgentInteraction-like object (duck-typed: has a string content attr)
+        content = getattr(chunk, "content", None)
+        if isinstance(content, str) and content:
+            return {"role": getattr(chunk, "role", None) or "assistant", "content": content}
+        return None
+    messages = chunk.get("messages")
+    if isinstance(messages, list) and messages and isinstance(messages[0], dict):
+        message = messages[0]
+        if message.get("content") is not None:
+            return {"role": message.get("role") or "assistant", "content": message["content"]}
+        return None
+    message = chunk.get("message")
+    if isinstance(message, dict) and message.get("content") is not None:
+        return {"role": message.get("role") or "assistant", "content": message["content"]}
+    choices = chunk.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        choice0 = choices[0]
+        message = choice0.get("delta") or choice0.get("message") or choice0
+        if isinstance(message, dict) and message.get("content") is not None:
+            return {"role": message.get("role") or "assistant", "content": message["content"]}
+        return None
+    # Bare top-level message dict (e.g. {"type": "message", "role": ..., "content": ...})
+    if chunk.get("content") is not None and (chunk.get("role") or chunk.get("type") == "message"):
+        return {"role": chunk.get("role") or "assistant", "content": chunk["content"]}
+    return None
+
+
+def _chunk_is_final(chunk: Any) -> bool:
+    """True when a chunk carries an explicit final marker (e.g. AgentInteraction.final)."""
+    if isinstance(chunk, dict):
+        return bool(chunk.get("final"))
+    return bool(getattr(chunk, "final", False))
+
+
+# ==============================================================================
 # API Views (DRF based)
 # ==============================================================================
 
@@ -86,36 +141,31 @@ class ChatCompletionsView(APIView):
     async def _handle_non_streaming(self, blueprint_instance, messages: list[dict[str, str]], request_id: str, model_name: str) -> Response:
         """ Handles non-streaming requests. """
         logger.info(f"[ReqID: {request_id}] Processing non-streaming request for model '{model_name}'.")
-        final_response_data = None
+        final_message = None
         start_time = time.time()
         try:
-            # The blueprint's run method should be an async generator.
+            # The blueprint's run method should be an async generator. Blueprints
+            # yield progress chunks (spinner frames like "Generating.") BEFORE the
+            # real answer, so we must consume the WHOLE generator and keep the
+            # LAST message — the same content the streaming path emits last.
+            # Chunks carrying an explicit final marker (AgentInteraction.final)
+            # short-circuit the scan.
             async_generator = blueprint_instance.run(messages, stream=False)
             async for chunk in async_generator:
-                # Accept either internal {messages:[{role,content}]} or OpenAI-like completion objects
-                if isinstance(chunk, dict):
-                    if "messages" in chunk and isinstance(chunk["messages"], list):
-                        final_response_data = chunk["messages"]
-                        logger.debug(f"[ReqID: {request_id}] Received final data chunk (messages list).")
-                        break
-                    if "choices" in chunk and isinstance(chunk.get("choices"), list) and chunk["choices"]:
-                        choice0 = chunk["choices"][0]
-                        message = choice0.get("message") or {}
-                        if isinstance(message, dict) and message.get("role") and (message.get("content") is not None):
-                            final_response_data = [message]
-                            logger.debug(f"[ReqID: {request_id}] Received final data chunk (OpenAI object).")
-                            break
-                logger.warning(f"[ReqID: {request_id}] Unexpected chunk format during non-streaming run: {chunk}")
+                message = _extract_message_from_chunk(chunk)
+                if message is None:
+                    logger.debug(f"[ReqID: {request_id}] Skipping non-message chunk during non-streaming run: {chunk}")
+                    continue
+                final_message = message
+                if _chunk_is_final(chunk):
+                    logger.debug(f"[ReqID: {request_id}] Received explicitly-final chunk; stopping consumption.")
+                    break
 
-            if not final_response_data or not isinstance(final_response_data, list) or not final_response_data:
-                 logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' did not return a valid final message list. Got: {final_response_data}")
+            if not isinstance(final_message, dict) or final_message.get('content') is None:
+                 logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' did not yield any valid message chunk.")
                  raise APIException("Blueprint did not return valid data.", code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-            if not isinstance(final_response_data[0], dict) or 'role' not in final_response_data[0]:
-                 logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' returned invalid message structure. Got: {final_response_data[0]}")
-                 raise APIException("Blueprint returned invalid message structure.", code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_response_data[0], "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}, "system_fingerprint": None }
+            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_message, "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}, "system_fingerprint": None }
             end_time = time.time()
             logger.info(f"[ReqID: {request_id}] Non-streaming request completed in {end_time - start_time:.2f}s.")
             return Response(response_payload, status=status.HTTP_200_OK)
@@ -137,23 +187,11 @@ class ChatCompletionsView(APIView):
                 logger.debug(f"[ReqID: {request_id}] Got async generator. Starting iteration...")
                 async for chunk in async_generator:
                     logger.debug(f"[ReqID: {request_id}] Received stream chunk {chunk_index}: {chunk}")
-                    delta = {"role": "assistant"}
-                    if isinstance(chunk, dict):
-                        if "messages" in chunk and isinstance(chunk["messages"], list) and chunk["messages"] and isinstance(chunk["messages"][0], dict):
-                            delta_content = chunk["messages"][0].get("content")
-                            if delta_content is not None:
-                                delta["content"] = delta_content
-                        elif "choices" in chunk and isinstance(chunk.get("choices"), list) and chunk["choices"]:
-                            # Handle OpenAI-like streaming or completion chunk shapes
-                            choice0 = chunk["choices"][0]
-                            if isinstance(choice0, dict):
-                                # delta content (streaming) or message content (completion)
-                                message = choice0.get("delta") or choice0.get("message") or {}
-                                if isinstance(message, dict) and (message.get("content") is not None):
-                                    delta["content"] = message.get("content")
-                    if "content" not in delta:
+                    message = _extract_message_from_chunk(chunk)
+                    if message is None:
                         logger.warning(f"[ReqID: {request_id}] Skipping invalid chunk format: {chunk}")
                         continue
+                    delta = {"role": "assistant", "content": message["content"]}
                     response_chunk = { "id": f"chatcmpl-{request_id}", "object": "chat.completion.chunk", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "delta": delta, "logprobs": None, "finish_reason": None}] }
                     logger.debug(f"[ReqID: {request_id}] Sending SSE chunk {chunk_index}")
                     yield f"data: {json.dumps(response_chunk)}\n\n"

--- a/tests/api/test_blueprint_api_smoke.py
+++ b/tests/api/test_blueprint_api_smoke.py
@@ -1,0 +1,99 @@
+"""Per-blueprint API smoke tests (SWARM_TEST_MODE).
+
+Guards the regression where non-streaming /v1/chat/completions returned
+spinner text ("Generating.") instead of the blueprint's real answer, and
+asserts every discoverable blueprint answers over the API surface.
+"""
+
+import json
+
+import pytest
+from django.test import Client
+
+from swarm.core.blueprint_discovery import discover_blueprints
+from swarm.settings import BLUEPRINT_DIRECTORY
+
+
+def _blueprint_ids() -> list[str]:
+    # Discovery imports blueprint modules via file specs, inserting
+    # sys.modules entries without proper parent packages — which breaks later
+    # real `import swarm.blueprints.<x>.<y>` statements in other test modules.
+    # Snapshot and purge whatever discovery adds so collection stays clean.
+    import sys
+
+    before = set(sys.modules)
+    try:
+        ids = sorted(discover_blueprints(str(BLUEPRINT_DIRECTORY)).keys())
+    except TypeError:
+        ids = sorted(discover_blueprints(directories=[BLUEPRINT_DIRECTORY]).keys())
+    for name in set(sys.modules) - before:
+        if name.startswith("swarm.blueprints"):
+            del sys.modules[name]
+    return ids
+
+
+BLUEPRINTS = _blueprint_ids()
+
+# Blueprints that genuinely cannot answer over the API today, with reasons.
+XFAIL: dict[str, str] = {
+    "whiskeytango_foxtrot": (
+        "run() hangs in SWARM_TEST_MODE (no canned-response path; spawns its "
+        "multi-tier agent loop) — tracked in ROADMAP"
+    ),
+}
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch):
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+
+
+def _post_completion(client: Client, model: str, stream: bool):
+    return client.post(
+        "/v1/chat/completions",
+        data=json.dumps(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "ping"}],
+                **({"stream": True} if stream else {}),
+            }
+        ),
+        content_type="application/json",
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("blueprint_id", BLUEPRINTS)
+def test_non_streaming_returns_real_answer(client, blueprint_id):
+    if blueprint_id in XFAIL:
+        pytest.xfail(XFAIL[blueprint_id])
+    response = _post_completion(client, blueprint_id, stream=False)
+    assert response.status_code == 200, response.content[:300]
+    payload = response.json()
+    assert payload.get("object") == "chat.completion"
+    content = payload["choices"][0]["message"]["content"]
+    assert content and content.strip(), "empty completion content"
+    assert not content.startswith("Generating"), (
+        f"spinner text leaked as the answer: {content[:80]!r}"
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("blueprint_id", BLUEPRINTS)
+def test_streaming_emits_done(client, blueprint_id):
+    if blueprint_id in XFAIL:
+        pytest.xfail(XFAIL[blueprint_id])
+    response = _post_completion(client, blueprint_id, stream=True)
+    assert response.status_code == 200, getattr(response, "content", b"")[:300]
+    stream = response.streaming_content
+    if hasattr(stream, "__aiter__"):  # async streaming response under test client
+        import asyncio
+
+        async def _collect():
+            return b"".join([chunk async for chunk in stream])
+
+        body = asyncio.run(_collect()).decode()
+    else:
+        body = b"".join(stream).decode()
+    assert "data: [DONE]" in body
+    assert '"content"' in body

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -3291,27 +3291,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3377,14 +3356,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -5110,14 +5081,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7761,17 +7724,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8367,36 +8319,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8469,14 +8391,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -10244,24 +10158,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",


### PR DESCRIPTION
Fixes the ROADMAP known issue: non-streaming /v1/chat/completions returned spinner text in test mode. 28-case smoke matrix: 13 blueprints verified on both streaming and non-streaming surfaces (previously only zeus). One honest xfail (whiskeytango_foxtrot hangs in test mode, tracked). Agent work completed after a session-limit interruption; core fix reviewed line-by-line and live-verified via curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)