### PR TITLE
fix(wtf): test-mode canned response in run(), clearing last blueprint smoke xfail

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Last updated: 2026-06-11 (post PR waves #80–#85; origin reduced to main; Docke
 
 - [x] **ASGI routing for websocket chat** — `swarm/asgi.py` + `routing.py` created; daphne/channels registered (they were declared core deps all along, never wired); 9 full-stack tests; live-verified 101 upgrade with session auth, 403 anonymous/bad-origin (`docs/websocket_chat.md`)
 
-- [x] **Non-streaming `/v1/chat/completions` test-mode bug FIXED** — chunk normalizer consumes the whole generator and returns the final message (was: first spinner chunk). Per-blueprint API smoke matrix added (`tests/api/test_blueprint_api_smoke.py`): 13 blueprints verified answering on BOTH streaming and non-streaming surfaces (was: only zeus). Remaining xfail: `whiskeytango_foxtrot` hangs in test mode (no canned-response path) — fix its run() or demote to examples.
+- [x] **Non-streaming `/v1/chat/completions` test-mode bug FIXED** — chunk normalizer consumes the whole generator and returns the final message (was: first spinner chunk). Per-blueprint API smoke matrix added (`tests/api/test_blueprint_api_smoke.py`): 13 blueprints verified answering on BOTH streaming and non-streaming surfaces (was: only zeus). Former xfail RESOLVED: `whiskeytango_foxtrot` now yields a canned `[TEST-MODE]` answer early in run() instead of hanging — all 14 blueprints pass the smoke matrix.
 
 ### 2.1 Deprecation shim sunset
 

--- a/src/swarm/blueprints/whiskeytango_foxtrot/blueprint_whiskeytango_foxtrot.py
+++ b/src/swarm/blueprints/whiskeytango_foxtrot/blueprint_whiskeytango_foxtrot.py
@@ -216,6 +216,11 @@ class WhiskeyTangoFoxtrotBlueprint(BlueprintBase):
         """Main execution entry point for the WhiskeyTangoFoxtrot blueprint."""
         logger.info("WhiskeyTangoFoxtrotBlueprint run method called.")
         instruction = messages[-1].get("content", "") if messages else ""
+        # --- Test Mode: yield a canned answer immediately, never spawn the
+        # multi-tier agent loop (which hangs without a live LLM). ---
+        if os.environ.get("SWARM_TEST_MODE"):
+            yield {"messages": [{"role": "assistant", "content": f"[TEST-MODE] WhiskeyTangoFoxtrot tracking free services. You said: '{instruction}'"}]}
+            return
         from agents import Runner
         ux = BlueprintUXImproved(style="serious")
         spinner_idx = 0

--- a/tests/api/test_blueprint_api_smoke.py
+++ b/tests/api/test_blueprint_api_smoke.py
@@ -35,12 +35,7 @@ def _blueprint_ids() -> list[str]:
 BLUEPRINTS = _blueprint_ids()
 
 # Blueprints that genuinely cannot answer over the API today, with reasons.
-XFAIL: dict[str, str] = {
-    "whiskeytango_foxtrot": (
-        "run() hangs in SWARM_TEST_MODE (no canned-response path; spawns its "
-        "multi-tier agent loop) — tracked in ROADMAP"
-    ),
-}
+XFAIL: dict[str, str] = {}
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- `whiskeytango_foxtrot`'s `run()` hung under `SWARM_TEST_MODE` when invoked via the API: it spawned its multi-tier agent loop with no canned-response path. This adds an early test-mode branch (same pattern as zeus/jeeves/whinge_surf) that immediately yields `[TEST-MODE] WhiskeyTangoFoxtrot tracking free services. You said: '<last user message>'` and returns. The real (non-test-mode) path is untouched.
- Removed the `whiskeytango_foxtrot` entry from `XFAIL` in `tests/api/test_blueprint_api_smoke.py` (dict now empty — kept for future use).
- Updated the ROADMAP xfail note to resolved: all 14 blueprints now pass the smoke matrix.

## Test plan
- `uv run pytest tests/api/test_blueprint_api_smoke.py -q --timeout=30 --timeout-method=thread` → **28 passed, 0 xfail**
- Full suite `uv run pytest -q --timeout=180 -p no:cacheprovider` → **892 passed, 9 skipped, 0 failed** (baseline 890 + the two former xfails now passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)