### PR TITLE
release: 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.3.2] - 2026-06-11
+
+### Fixed
+- SPA shipped unstyled (Tailwind v4/v3 config mismatch emitted ~2kB CSS); DaisyUI 5 `card-bordered` removal made card borders invisible app-wide
+- Django navbar dropdowns rendered as empty white boxes; duplicate element id
+- Non-streaming `/v1/chat/completions` returned spinner text in test mode; all 14 blueprints now answer on both API surfaces (smoke matrix added)
+- Mobile: SPA bottom nav never rendered (DaisyUI 4 class); viewport overflows fixed
+
+### Added
+- Guided tour + screenshot registry + README demo GIF; CI visual-regression workflow (golden journey, computed-style guards)
+- SPA: agent-creator and settings pages, token auth UX, websocket ChatPage; theme-token dark mode toggle
+- Mobile captures (13 pages); capture harness authenticates and migrates fresh DBs
+
+### Changed
+- Branding: project name is "Open Swarm" (dropped stale "MCP" suffix)
+
 ## [0.3.1] - 2026-06-11
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -173,6 +173,22 @@ Keys (all optional except `backend`):
 | `limit`   | Max memory snippets returned per search (default: `5`). |
 | `config`  | Dict passed verbatim to `mem0.Memory.from_config(...)` (vector store, LLM, etc. — see mem0 docs). Omit to use mem0's defaults. |
 
+**Custom OpenAI-compatible endpoint (e.g. LiteLLM):** mem0 accepts a base-URL
+override per component via the `config` block (forwarded verbatim):
+
+```json
+"memory": {
+  "backend": "mem0",
+  "config": {
+    "llm":      {"provider": "openai", "config": {"model": "gpt-4o-mini", "openai_base_url": "${LITELLM_BASE_URL}", "api_key": "${LITELLM_API_KEY}"}},
+    "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small", "openai_base_url": "${LITELLM_BASE_URL}", "api_key": "${LITELLM_API_KEY}"}}
+  }
+}
+```
+
+Note: the endpoint must also proxy an **embeddings** model — mem0 needs one
+for its vector store, not just a chat model.
+
 ### Behavior
 
 - **Pre-run retrieval:** before each `run()`, the latest user message is used to search memory; any hits are prepended as a single system message (`"Relevant memories from previous conversations: ..."`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.3.1"
+version = "0.3.2"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Version bump + changelog for the UX/API-matrix/mobile wave; documents mem0 base-URL override for LiteLLM endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)