### PR TITLE
ci: run frontend vitest suite

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -34,6 +34,7 @@ jobs:
         working-directory: webui/frontend
         run: |
           npm ci
+          npm test
           npm run build
           # Fail loudly here too if the bundle is suspiciously small.
           ls -l dist/assets/

--- a/webui/frontend/package.json
+++ b/webui/frontend/package.json
@@ -29,7 +29,8 @@
     "serve": "vite preview",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Wires #105's a11y vitest suite into CI (npm test in the visual-regression workflow). Verified locally: 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)