### PR TITLE
feat: CLI Agent Fusion — foundation (v0.4.0 PR 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `model` field selects which blueprint handles the request. Streaming is supp
 * **Agents** — individual AI workers powered by LLMs, built on the `openai-agents` SDK (agents, tools, handoffs).
 * **Blueprints** — `BlueprintBase` subclasses defining a team: its agents, coordination logic, tools, and required MCP servers/env vars. Discovered by directory scan; each blueprint is independently runnable, testable, and compilable. Blueprints can call other blueprints as tools (`swarm.core.blueprint_utils.blueprint_tool`).
 * **MCP servers** — external tool providers (filesystem, search, databases, …) declared **in config, not code**; agents get their tools at runtime via the Model Context Protocol.
+* **CLI agents & fusion** — wrap your installed agentic CLIs (`claude`, `gemini`, `codex`, `opencode`, …) as subagents behind the OpenAI API. `model: "cli_agent"` runs one; `model: "cli_fusion"` fans a prompt to a panel of them in parallel, judges and synthesizes the answers, and can iterate a bounded master plan. OpenRouter-Fusion-style, with your local toolbox. See [docs/CLI_FUSION.md](docs/CLI_FUSION.md).
 * **Configuration** — one JSON file (`~/.config/swarm/swarm_config.json`) holding named LLM profiles and MCP server definitions, with `${ENV_VAR}` placeholders so secrets stay in the environment / `.env`.
 
 ### Example `swarm_config.json`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Detailed nested progress lives in [ROADMAP.md](./ROADMAP.md); per-feature eviden
 - [ ] **MCP server mode** (`ENABLE_MCP_SERVER`) — aspirational; the flag warns loudly and [docs/mcp_server_mode.md](./docs/mcp_server_mode.md) documents real adoption options
 - [ ] **Memory** — mem0 is wired into the agent loop (opt-in) and documented in [CONFIGURATION.md](./CONFIGURATION.md), but not yet validated against a live mem0 end-to-end; letta/langmem are placeholders
 - [ ] **Deprecation-shim sunset** — 7 import shims from the consolidation get removed in the release after v0.3.x
+- [ ] **CLI fusion follow-ups** — the `cli_agent`/`cli_fusion` blueprints work end-to-end ([docs/CLI_FUSION.md](./docs/CLI_FUSION.md)); next: extract the panel→judge→synthesize loop into a reusable `swarm.core.cli_fusion` service for the websocket/CLI front-ends, and add opt-in git-worktree isolation for write-mode panels
 
 ## Acknowledgements & Attribution
 

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -1,0 +1,196 @@
+# CLI Fusion — your installed agentic CLIs, behind one OpenAI endpoint
+
+Most agentic CLIs (`claude`, `gemini`, `codex`, `opencode`, …) are powerful but
+**not** OpenAI-compatible, and each only orchestrates its own model's subagents.
+Open Swarm's CLI-fusion blueprints turn whatever CLIs you already have installed
+into composable, API-addressable subagents:
+
+- **`cli_agent`** — expose a *single* CLI over `/v1/chat/completions`.
+- **`cli_fusion`** — fan a prompt to a *panel* of CLIs in parallel, have a
+  *judge* compare their answers, *synthesize* a single best answer, and
+  optionally iterate a bounded **master plan** (the judge decides the next step).
+
+Inspired by [OpenRouter Fusion](https://openrouter.ai/docs/guides/features/plugins/fusion),
+except the panelists are *your local toolbox*, not a fixed hosted set — and they
+can use any tools their own CLI provides (MCP servers, file access, web, …).
+
+Any OpenAI client (Open WebUI, Cursor, the OpenAI SDK, a shell script) talks to
+them with no changes — just point at the Open Swarm API and pick the model name.
+
+---
+
+## Quick start
+
+1. Add a `cli_agents` block (and optionally `cli_fusion`) to your
+   `~/.config/swarm/swarm_config.json` — see [the example](#full-example) below.
+2. Make sure the CLIs are installed and **logged in** on the host (each CLI
+   authenticates itself; Open Swarm does not proxy their credentials).
+3. Call the API:
+
+```bash
+# Single CLI:
+curl -sf http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer ${API_AUTH_TOKEN}" -H "Content-Type: application/json" \
+  -d '{"model":"cli_agent","messages":[{"role":"user","content":"Explain this repo"}],
+       "params":{"cli":"claude"}}' | jq -r '.choices[0].message.content'
+
+# Fusion panel:
+curl -sf http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer ${API_AUTH_TOKEN}" -H "Content-Type: application/json" \
+  -d '{"model":"cli_fusion","messages":[{"role":"user","content":"Design a rate limiter"}],
+       "params":{"preset":"general-high","show_analysis":true}}' | jq -r '.choices[0].message.content'
+```
+
+`params` is the standard Open Swarm per-request field; OpenAI SDKs send it via
+`extra_body={"params": {...}}`.
+
+---
+
+## Config: `cli_agents`
+
+Each entry declares how to run one CLI **one-shot**. The command is an argv list
+executed directly (no shell), so the prompt is never interpolated into a shell
+string.
+
+| Key | Type | Meaning |
+|---|---|---|
+| `cmd` | list[str] | argv. Put `{prompt}` where the prompt goes; `{workdir}` for the working dir. |
+| `prompt_mode` | `"arg"` \| `"stdin"` | `arg` (default) substitutes `{prompt}` into `cmd`; `stdin` pipes it to stdin. |
+| `parse` | `"text"` \| `"json:<dotpath>"` | `text` (default) = trimmed stdout. `json:.result` parses JSON and extracts a dotted path (list indices allowed, e.g. `json:.choices.0.message.content`). |
+| `cwd` | str | Working directory template (`{workdir}` allowed). Defaults to the per-request `workdir` or the server CWD. |
+| `env` | dict | Extra env vars merged onto the child's environment. |
+| `env_allowlist` | list[str] \| null | **null (default):** child inherits the full environment (convenient, but every panelist sees every API key). **Set it:** child gets only these vars plus essentials (`PATH`, `HOME`, …) — isolates each CLI's secrets. |
+| `timeout` | number | Seconds before the CLI (and its whole process group) is killed. Default 180. |
+| `mode` | str | Free-text label documenting safety posture (`"readonly"`, `"write"`). Advisory. |
+
+> ⚠️ **Exact flags and JSON shapes vary by CLI version.** The snippets below are
+> starting points — run the CLI's `--help` and confirm its non-interactive flag,
+> its read-only/approval mode, and (if using `json:` parse) the actual key in its
+> JSON output. When in doubt, use `parse: "text"`.
+
+### Example adapters
+
+```jsonc
+"cli_agents": {
+  "claude": {
+    "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
+            "--allowedTools", "Read,Grep,Glob"],
+    "parse": "json:.result",
+    "mode": "readonly",
+    "timeout": 240
+  },
+  "gemini": {
+    "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--approval-mode", "plan"],
+    "parse": "json:.response",
+    "mode": "readonly"
+  },
+  "codex": {
+    "cmd": ["codex", "exec", "{prompt}"],
+    "parse": "text"
+  },
+  "opencode": {
+    "cmd": ["opencode", "run", "{prompt}"],
+    "parse": "text"
+  }
+}
+```
+
+`--allowedTools Read,Grep,Glob` (claude) and `--approval-mode plan` (gemini) keep
+panelists **read-only** — strongly recommended when fanning out in parallel (see
+[Safety](#safety)).
+
+---
+
+## Config: `cli_fusion`
+
+| Key | Type | Meaning |
+|---|---|---|
+| `default_cli` | str | Which adapter the `cli_agent` blueprint uses when the request doesn't name one. |
+| `presets` | dict | Named panels. Each preset: `{ "panel": [names], "judge": name }`. |
+| `default_preset` | str | Preset used by `cli_fusion` when the request doesn't specify a panel/preset. |
+| `max_rounds` | int | Master-plan rounds (default 1, hard-capped at 5). |
+| `show_analysis` | bool | Append the judge's consensus/contradictions/gaps footer to the answer. |
+
+```jsonc
+"cli_fusion": {
+  "default_cli": "claude",
+  "default_preset": "general-high",
+  "max_rounds": 1,
+  "show_analysis": false,
+  "presets": {
+    "general-high":   { "panel": ["claude", "gemini", "codex"], "judge": "claude" },
+    "general-budget": { "panel": ["gemini"],                    "judge": "gemini" }
+  }
+}
+```
+
+### Per-request `params`
+
+| Param | Applies to | Meaning |
+|---|---|---|
+| `cli` | cli_agent | Which adapter to run. |
+| `panel` | cli_fusion | Explicit list of adapter names (overrides preset). |
+| `preset` | cli_fusion | Named preset to use. |
+| `judge` | cli_fusion | Judge adapter (overrides preset's). |
+| `max_rounds` | cli_fusion | Override master-plan rounds (capped at 5). |
+| `show_analysis` | cli_fusion | Override the analysis footer. |
+| `timeout` | both | Override every adapter's timeout for this request. |
+| `workdir` | both | Working directory for the CLI(s). |
+
+---
+
+## How fusion works
+
+```
+prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
+            │
+            ▼
+        judge CLI: compares (not concatenates) the answers → structured JSON
+            { consensus, contradictions, gaps, unique_insights, answer, done, next_step }
+            │
+            ▼
+        synthesize: judge's "answer" (or longest panel answer if no judge)
+            │
+       done? ──no──► feed answer + next_step back as the next round's prompt
+            │
+           yes ─► final answer (the only chunk marked final)
+```
+
+- **No judge configured?** Fusion still works — it falls back to the longest
+  successful panel answer.
+- **Master plan:** when `max_rounds > 1` and the judge returns `"done": false`,
+  its `"next_step"` becomes the next round's instruction. The loop stops on
+  `done`, at `max_rounds`, or if every panelist fails.
+- **Progress** (per-round panel/judge status) streams as a side-channel chunk
+  (`{"type":"fusion_progress"}`) that vanilla OpenAI clients ignore, so it never
+  pollutes the synthesized answer.
+
+---
+
+## Safety
+
+CLI agents can read files, run commands, and reach the network. Treat them as
+untrusted, side-effecting processes:
+
+- **Read-only panelists by default.** Use each CLI's plan/read-only mode
+  (`--approval-mode plan`, `--allowedTools Read,Grep,…`). Only opt specific
+  adapters into write mode, and avoid running several write-mode CLIs in the same
+  `workdir` in parallel — give them separate `workdir`s.
+- **Timeouts always.** Interactive CLIs hang waiting for input if you get the
+  non-interactive flag wrong. Every adapter has a `timeout`; on expiry the whole
+  process group is killed (SIGTERM → SIGKILL).
+- **Secret isolation.** By default every panelist inherits the full environment.
+  Set `env_allowlist` per adapter so each CLI sees only the keys it needs.
+- **Recursion guard.** If a panelist CLI is itself pointed back at this Open
+  Swarm endpoint with `model: "cli_fusion"`, the `SWARM_CLI_FUSION_DEPTH` env var
+  (injected into children) makes nested fusion degrade to a single agent — no
+  fan-out explosion.
+- **Cost.** A panel of N agents over R rounds is ~N×R completions. Keep
+  `max_rounds` small and panels focused; use `general-budget` for cheap runs.
+
+---
+
+## Full example
+
+A complete, copy-pasteable config lives at
+[`docs/examples/cli_fusion.swarm_config.json`](examples/cli_fusion.swarm_config.json).

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -109,6 +109,7 @@ panelists **read-only** — strongly recommended when fanning out in parallel (s
 | `presets` | dict | Named panels. Each preset: `{ "panel": [names], "judge": name }`. |
 | `default_preset` | str | Preset used by `cli_fusion` when the request doesn't specify a panel/preset. |
 | `max_rounds` | int | Master-plan rounds (default 1, hard-capped at 5). |
+| `max_concurrency` | int | Max CLI subprocesses launched at once per round (default 8). |
 | `show_analysis` | bool | Append the judge's consensus/contradictions/gaps footer to the answer. |
 
 ```jsonc

--- a/docs/examples/cli_fusion.swarm_config.json
+++ b/docs/examples/cli_fusion.swarm_config.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Example Open Swarm config for the cli_agent and cli_fusion blueprints. Copy the cli_agents / cli_fusion blocks into your ~/.config/swarm/swarm_config.json. Flags and JSON-parse paths vary by CLI version — verify with each CLI's --help. See docs/CLI_FUSION.md.",
+
+  "llm": {
+    "default": {
+      "provider": "openai",
+      "model": "gpt-4o",
+      "base_url": "https://api.openai.com/v1",
+      "api_key": "${OPENAI_API_KEY}"
+    }
+  },
+
+  "cli_agents": {
+    "claude": {
+      "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
+              "--allowedTools", "Read,Grep,Glob"],
+      "parse": "json:.result",
+      "mode": "readonly",
+      "timeout": 240,
+      "env_allowlist": ["ANTHROPIC_API_KEY"]
+    },
+    "gemini": {
+      "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--approval-mode", "plan"],
+      "parse": "json:.response",
+      "mode": "readonly",
+      "timeout": 240,
+      "env_allowlist": ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    },
+    "codex": {
+      "cmd": ["codex", "exec", "{prompt}"],
+      "parse": "text",
+      "mode": "readonly",
+      "timeout": 240,
+      "env_allowlist": ["OPENAI_API_KEY"]
+    },
+    "opencode": {
+      "cmd": ["opencode", "run", "{prompt}"],
+      "parse": "text",
+      "timeout": 240
+    }
+  },
+
+  "cli_fusion": {
+    "default_cli": "claude",
+    "default_preset": "general-high",
+    "max_rounds": 1,
+    "show_analysis": false,
+    "presets": {
+      "general-high":   { "panel": ["claude", "gemini", "codex"], "judge": "claude" },
+      "general-budget": { "panel": ["gemini"],                    "judge": "gemini" }
+    }
+  }
+}

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -14,17 +14,11 @@ See :mod:`swarm.core.cli_adapter` for the lifecycle layer and
 from __future__ import annotations
 
 import logging
-import os
-import sys
 from typing import Any, ClassVar
-
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-src_path = os.path.join(project_root, "src")
-if src_path not in sys.path:
-    sys.path.insert(0, src_path)
 
 from swarm.blueprints.common import cli_fusion_support as support
 from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterError
 
 logger = logging.getLogger(__name__)
 
@@ -55,15 +49,18 @@ class CliAgentBlueprint(BlueprintBase):
         self._params = dict(params or {})
 
     async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        # Snapshot params once before any await: the API view may reuse a cached
+        # singleton instance for param-less requests, so self._params can be
+        # mutated by a concurrent request across await points.
+        params = dict(self._params)
+
         prompt = support.render_prompt(messages)
         if not prompt:
             yield support.message_chunk("No prompt provided.", final=True)
             return
 
-        registry = support.apply_overrides(
-            support.build_registry(self._config), self._params
-        )
-        name = support.select_single_cli(self._config, self._params, registry)
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        name = support.select_single_cli(self._config, params, registry)
         if not name:
             yield support.message_chunk(
                 "No CLI agents are configured. Add a 'cli_agents' block to your "
@@ -74,11 +71,11 @@ class CliAgentBlueprint(BlueprintBase):
 
         try:
             adapter = registry.get(name)
-        except Exception as exc:  # CliAdapterError
+        except CliAdapterError as exc:
             yield support.message_chunk(str(exc), final=True)
             return
 
-        workdir = self._params.get(support.PARAM_WORKDIR)
+        workdir = params.get(support.PARAM_WORKDIR)
         yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
         result = await adapter.run(prompt, workdir=workdir)
 

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -1,0 +1,95 @@
+"""CLI Agent blueprint — expose a single configured agentic CLI over the
+OpenAI-compatible API.
+
+This is the minimal drop-in: a request to ``model: "cli_agent"`` runs one
+configured CLI (``claude``, ``gemini``, ...) one-shot and streams its answer
+back as a normal chat completion. Which CLI runs is chosen by (in order) the
+per-request ``cli`` param, the config ``cli_fusion.default_cli``, or the first
+CLI actually installed on this host.
+
+See :mod:`swarm.core.cli_adapter` for the lifecycle layer and
+``cli_fusion`` for multi-CLI deliberation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any, ClassVar
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+src_path = os.path.join(project_root, "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+
+logger = logging.getLogger(__name__)
+
+
+class CliAgentBlueprint(BlueprintBase):
+    """Run one configured agentic CLI as an OpenAI-compatible model."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_agent",
+        "title": "CLI Agent (single external CLI)",
+        "description": (
+            "Expose a single configured agentic CLI (claude, gemini, codex, ...) "
+            "over the OpenAI-compatible API. The 'cli' param selects which one."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "subagent", "adapter", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_agent", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        """Capture per-request params forwarded by the API view."""
+        self._params = dict(params or {})
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(
+            support.build_registry(self._config), self._params
+        )
+        name = support.select_single_cli(self._config, self._params, registry)
+        if not name:
+            yield support.message_chunk(
+                "No CLI agents are configured. Add a 'cli_agents' block to your "
+                "swarm config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        try:
+            adapter = registry.get(name)
+        except Exception as exc:  # CliAdapterError
+            yield support.message_chunk(str(exc), final=True)
+            return
+
+        workdir = self._params.get(support.PARAM_WORKDIR)
+        yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
+        result = await adapter.run(prompt, workdir=workdir)
+
+        if not result.ok:
+            yield support.message_chunk(
+                support.format_cli_error(adapter, result.error or "unknown error"),
+                final=True,
+            )
+            return
+
+        content = result.text
+        if result.parse_error:
+            logger.warning("CLI %s parse issue: %s", name, result.parse_error)
+        yield support.message_chunk(content, final=True)

--- a/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
+++ b/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 
 # Bound the master-plan loop regardless of config, to cap cost/runaway.
 MAX_ROUNDS_CEILING = 5
+# Default cap on how many CLI subprocesses launch at once (each may spawn a tree).
+DEFAULT_MAX_CONCURRENCY = 8
 # Env flag used to stop a panelist that is itself a swarm fusion from re-fusing.
 DEPTH_ENV = "SWARM_CLI_FUSION_DEPTH"
 
@@ -115,11 +117,16 @@ class CliFusionBlueprint(BlueprintBase):
         prompt: str,
         workdir: str | None,
         child_env: dict[str, str],
+        max_concurrency: int,
     ) -> list[CliResult]:
         panel = registry.resolve_panel(panel_names)
-        return await asyncio.gather(
-            *(a.run(prompt, workdir=workdir, extra_env=child_env) for a in panel)
-        )
+        sem = asyncio.Semaphore(max(1, max_concurrency))
+
+        async def _bounded(adapter):
+            async with sem:
+                return await adapter.run(prompt, workdir=workdir, extra_env=child_env)
+
+        return await asyncio.gather(*(_bounded(a) for a in panel))
 
     async def _judge(
         self,
@@ -198,6 +205,12 @@ class CliFusionBlueprint(BlueprintBase):
 
         fusion_cfg = (self._config or {}).get("cli_fusion") or {}
         workdir = params.get(support.PARAM_WORKDIR)
+        try:
+            max_concurrency = int(
+                params.get("max_concurrency", fusion_cfg.get("max_concurrency", DEFAULT_MAX_CONCURRENCY))
+            )
+        except (TypeError, ValueError):
+            max_concurrency = DEFAULT_MAX_CONCURRENCY
 
         # Recursion guard: if we are running *inside* another fusion (a panelist
         # was itself a swarm fusion blueprint), degrade to a single panelist with
@@ -223,7 +236,7 @@ class CliFusionBlueprint(BlueprintBase):
                 f"CLI agent(s): {', '.join(panel_names)}…_"
             )
             results = await self._run_panel(
-                registry, panel_names, current_prompt, workdir, child_env
+                registry, panel_names, current_prompt, workdir, child_env, max_concurrency
             )
             for r in results:
                 if not r.ok:

--- a/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
+++ b/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
@@ -1,0 +1,256 @@
+"""CLI Fusion blueprint — multi-CLI deliberation over the OpenAI API.
+
+Fans a prompt out to a *panel* of configured agentic CLIs in parallel, has a
+*judge* CLI compare their outputs into a structured analysis, *synthesizes* a
+final answer, and (optionally) drives a bounded *master-plan loop* that feeds
+the judge's "next step" back into another round.
+
+Inspired by OpenRouter Fusion, but the panelists are whatever CLI agents the
+operator has installed (``claude``, ``gemini``, ``codex``, ...). Selection is
+config/preset driven; see ``docs/CLI_FUSION.md``.
+
+Request model: ``model: "cli_fusion"``. Per-request ``params`` may set
+``panel`` (list), ``preset``, ``judge``, ``max_rounds``, ``timeout``, ``workdir``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry, CliResult
+
+logger = logging.getLogger(__name__)
+
+# Bound the master-plan loop regardless of config, to cap cost/runaway.
+MAX_ROUNDS_CEILING = 5
+# Env flag used to stop a panelist that is itself a swarm fusion from re-fusing.
+DEPTH_ENV = "SWARM_CLI_FUSION_DEPTH"
+
+JUDGE_TEMPLATE = """You are the JUDGE in a multi-agent panel. The user's request was:
+
+<request>
+{prompt}
+</request>
+
+Several independent agents answered it. Compare (do NOT merely concatenate) their answers below.
+
+{panel}
+
+Return ONLY a JSON object with these keys:
+- "consensus": list of points the agents agree on
+- "contradictions": list of points where they disagree
+- "gaps": list of things no agent covered
+- "unique_insights": list of valuable points raised by a single agent
+- "answer": a single best synthesized answer combining the strongest reasoning from all agents
+- "done": boolean — true if "answer" fully resolves the request, false if another round of work is needed
+- "next_step": if not done, one concrete instruction for the next round (else "")
+"""
+
+
+def _safe_json(text: str) -> dict[str, Any] | None:
+    """Parse a JSON object from CLI output, tolerating surrounding prose."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start, end = text.find("{"), text.rfind("}")
+    if 0 <= start < end:
+        try:
+            obj = json.loads(text[start : end + 1])
+            return obj if isinstance(obj, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+class CliFusionBlueprint(BlueprintBase):
+    """Panel → judge → synthesize, with an optional bounded master-plan loop."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_fusion",
+        "title": "CLI Fusion (multi-CLI deliberation)",
+        "description": (
+            "Fan a prompt to a panel of configured agentic CLIs in parallel, "
+            "judge and synthesize their answers, and optionally iterate a "
+            "master plan. OpenRouter-Fusion-style, with your installed CLIs."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "fusion", "multi-agent", "deliberation", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_fusion", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    # --- helpers -------------------------------------------------------- #
+
+    def _max_rounds(self, params: dict[str, Any], fusion_cfg: dict[str, Any]) -> int:
+        raw = params.get("max_rounds", fusion_cfg.get("max_rounds", 1))
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            n = 1
+        return max(1, min(n, MAX_ROUNDS_CEILING))
+
+    async def _run_panel(
+        self,
+        registry: CliAdapterRegistry,
+        panel_names: list[str],
+        prompt: str,
+        workdir: str | None,
+        child_env: dict[str, str],
+    ) -> list[CliResult]:
+        panel = registry.resolve_panel(panel_names)
+        return await asyncio.gather(
+            *(a.run(prompt, workdir=workdir, extra_env=child_env) for a in panel)
+        )
+
+    async def _judge(
+        self,
+        registry: CliAdapterRegistry,
+        judge_name: str | None,
+        prompt: str,
+        results: list[CliResult],
+        workdir: str | None,
+        child_env: dict[str, str],
+    ) -> dict[str, Any] | None:
+        if not judge_name:
+            return None
+        try:
+            judge = registry.get(judge_name)
+        except Exception:
+            return None
+        panel_text = "\n\n".join(f"### Agent: {r.name}\n{r.text}" for r in results)
+        judge_prompt = JUDGE_TEMPLATE.format(prompt=prompt, panel=panel_text)
+        res = await judge.run(judge_prompt, workdir=workdir, extra_env=child_env)
+        if not res.ok:
+            logger.warning("Judge %s failed: %s", judge_name, res.error)
+            return None
+        return _safe_json(res.text)
+
+    @staticmethod
+    def _synthesize(analysis: dict[str, Any] | None, results: list[CliResult]) -> str:
+        if analysis and isinstance(analysis.get("answer"), str) and analysis["answer"].strip():
+            return analysis["answer"].strip()
+        # No usable judge analysis: fall back to the longest successful answer.
+        best = max(results, key=lambda r: len(r.text or ""))
+        return best.text
+
+    def _format_final(
+        self,
+        params: dict[str, Any],
+        answer: str,
+        analysis: dict[str, Any] | None,
+        results: list[CliResult],
+        rounds: int,
+    ) -> str:
+        show = params.get("show_analysis")
+        if show is None:
+            show = ((self._config or {}).get("cli_fusion") or {}).get("show_analysis", False)
+        if not show:
+            return answer
+        lines = [answer, "", "---", f"_Fusion: {len(results)} agents, {rounds} round(s)._"]
+        if analysis:
+            for key in ("consensus", "contradictions", "gaps", "unique_insights"):
+                vals = analysis.get(key)
+                if vals:
+                    rendered = "; ".join(str(v) for v in vals) if isinstance(vals, list) else str(vals)
+                    lines.append(f"- **{key}**: {rendered}")
+        return "\n".join(lines)
+
+    # --- entry point ---------------------------------------------------- #
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        # Snapshot params once before any await (see blueprint_cli_agent for why):
+        # a cached singleton instance may be shared across concurrent requests.
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        panel_names, judge_name = support.resolve_panel(self._config, params, registry)
+        if not panel_names:
+            yield support.message_chunk(
+                "No CLI agents are configured for fusion. Add a 'cli_agents' block "
+                "and a 'cli_fusion' preset to your swarm config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        fusion_cfg = (self._config or {}).get("cli_fusion") or {}
+        workdir = params.get(support.PARAM_WORKDIR)
+
+        # Recursion guard: if we are running *inside* another fusion (a panelist
+        # was itself a swarm fusion blueprint), degrade to a single panelist with
+        # no further fan-out so the tree cannot explode.
+        depth = 0
+        try:
+            depth = int(os.environ.get(DEPTH_ENV, "0"))
+        except ValueError:
+            depth = 0
+        if depth >= 1:
+            panel_names = panel_names[:1]
+            judge_name = None
+            max_rounds = 1
+            yield support.progress_chunk("_Nested fusion detected; running a single agent._")
+        else:
+            max_rounds = self._max_rounds(params, fusion_cfg)
+        child_env = {DEPTH_ENV: str(depth + 1)}
+
+        current_prompt = prompt
+        for round_i in range(max_rounds):
+            yield support.progress_chunk(
+                f"_Round {round_i + 1}/{max_rounds}: consulting {len(panel_names)} "
+                f"CLI agent(s): {', '.join(panel_names)}…_"
+            )
+            results = await self._run_panel(
+                registry, panel_names, current_prompt, workdir, child_env
+            )
+            for r in results:
+                if not r.ok:
+                    yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")
+            ok_results = [r for r in results if r.ok]
+            if not ok_results:
+                yield support.message_chunk("All CLI panelists failed.", final=True)
+                return
+
+            if judge_name:
+                yield support.progress_chunk(f"_Judging {len(ok_results)} response(s) with `{judge_name}`…_")
+            analysis = await self._judge(
+                registry, judge_name, current_prompt, ok_results, workdir, child_env
+            )
+            answer = self._synthesize(analysis, ok_results)
+            done = bool(analysis.get("done", True)) if analysis else True
+
+            if done or round_i == max_rounds - 1:
+                yield support.message_chunk(
+                    self._format_final(params, answer, analysis, ok_results, rounds=round_i + 1),
+                    final=True,
+                )
+                return
+
+            next_step = (analysis or {}).get("next_step") or "Refine and improve the answer."
+            yield support.progress_chunk(f"_Master plan → next step: {str(next_step)[:100]}_")
+            current_prompt = (
+                f"{prompt}\n\n--- Prior synthesized answer ---\n{answer}\n\n"
+                f"--- Next step ---\n{next_step}"
+            )

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -1,0 +1,141 @@
+"""Shared helpers for the CLI-agent blueprints (``cli_agent`` and ``cli_fusion``).
+
+Keeps prompt rendering, adapter-registry construction, panelist selection, and
+the chunk shapes blueprints yield in one place so the single-CLI and fusion
+blueprints stay consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from swarm.core.cli_adapter import CliAdapter, CliAdapterRegistry
+
+logger = logging.getLogger(__name__)
+
+# Per-request param keys recognised across the CLI blueprints.
+PARAM_CLI = "cli"            # single-CLI: which adapter to run
+PARAM_PANEL = "panel"        # fusion: list of adapter names
+PARAM_PRESET = "preset"      # fusion: named preset
+PARAM_JUDGE = "judge"        # fusion: judge adapter/profile
+PARAM_TIMEOUT = "timeout"    # override adapter timeout (seconds)
+PARAM_WORKDIR = "workdir"    # working directory for the CLI(s)
+
+
+def render_prompt(messages: list[dict[str, Any]]) -> str:
+    """Flatten an OpenAI-style message list into a single prompt string.
+
+    A lone user message is passed through verbatim. A multi-turn conversation
+    is rendered as a simple ``ROLE: content`` transcript so a one-shot CLI sees
+    the full context.
+    """
+    msgs = [m for m in (messages or []) if isinstance(m, dict) and m.get("content")]
+    if not msgs:
+        return ""
+    if len(msgs) == 1:
+        return str(msgs[0]["content"]).strip()
+    lines = []
+    for m in msgs:
+        role = (m.get("role") or "user").upper()
+        lines.append(f"{role}: {str(m['content']).strip()}")
+    return "\n\n".join(lines)
+
+
+def build_registry(config: dict[str, Any] | None) -> CliAdapterRegistry:
+    """Build the CLI adapter registry from the top-level swarm config."""
+    return CliAdapterRegistry.from_config(config or {})
+
+
+def _fusion_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    return ((config or {}).get("cli_fusion") or {})
+
+
+def select_single_cli(
+    config: dict[str, Any] | None,
+    params: dict[str, Any] | None,
+    registry: CliAdapterRegistry,
+) -> str | None:
+    """Pick the adapter name for the single-CLI blueprint.
+
+    Priority: per-request ``cli`` param > config ``cli_fusion.default_cli`` >
+    first available-on-host adapter > first configured adapter. Returns None
+    when no adapters are configured at all.
+    """
+    params = params or {}
+    requested = params.get(PARAM_CLI)
+    if requested:
+        return requested
+    default = _fusion_config(config).get("default_cli")
+    if default:
+        return default
+    available = registry.available()
+    if available:
+        return available[0]
+    names = registry.names()
+    return names[0] if names else None
+
+
+def resolve_panel(
+    config: dict[str, Any] | None,
+    params: dict[str, Any] | None,
+    registry: CliAdapterRegistry,
+) -> tuple[list[str], str | None]:
+    """Resolve (panel_names, judge_name) for the fusion blueprint.
+
+    Priority for the panel: per-request ``panel`` list > per-request ``preset``
+    > config ``cli_fusion.default_preset`` > all available adapters.
+    """
+    params = params or {}
+    fusion = _fusion_config(config)
+    presets = fusion.get("presets") or {}
+
+    panel: list[str] | None = params.get(PARAM_PANEL)
+    judge: str | None = params.get(PARAM_JUDGE)
+
+    preset_name = params.get(PARAM_PRESET) or (None if panel else fusion.get("default_preset"))
+    if not panel and preset_name and preset_name in presets:
+        preset = presets[preset_name] or {}
+        panel = preset.get("panel")
+        judge = judge or preset.get("judge")
+
+    if not panel:
+        panel = registry.available() or registry.names()
+
+    # Drop names with no configured adapter, keeping order.
+    known = set(registry.names())
+    panel = [n for n in panel if n in known]
+    if judge and judge not in known:
+        judge = None
+    return panel, judge
+
+
+def apply_overrides(
+    registry: CliAdapterRegistry, params: dict[str, Any] | None
+) -> CliAdapterRegistry:
+    """Apply per-request adapter overrides (currently: timeout) to a registry."""
+    params = params or {}
+    timeout = params.get(PARAM_TIMEOUT)
+    if timeout is None:
+        return registry
+    patch = {name: {"timeout": float(timeout)} for name in registry.names()}
+    return registry.with_overrides(patch)
+
+
+# --- Chunk helpers (match what swarm.views.chat_views expects to consume) --- #
+
+def message_chunk(content: str, *, final: bool = False, role: str = "assistant") -> dict:
+    """A content-bearing chunk. ``final=True`` lets the API short-circuit."""
+    chunk: dict[str, Any] = {"messages": [{"role": role, "content": content}]}
+    if final:
+        chunk["final"] = True
+    return chunk
+
+
+def progress_chunk(content: str) -> dict:
+    """A streamed progress line (rendered as a delta; harmless when buffered)."""
+    return {"messages": [{"role": "assistant", "content": content}]}
+
+
+def format_cli_error(adapter: CliAdapter, error: str) -> str:
+    return f"[{adapter.name}] failed: {error}"

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -132,9 +132,26 @@ def message_chunk(content: str, *, final: bool = False, role: str = "assistant")
     return chunk
 
 
+#: Chunk ``type`` for fusion progress side-channel events.
+PROGRESS_TYPE = "fusion_progress"
+
+
 def progress_chunk(content: str) -> dict:
-    """A streamed progress line (rendered as a delta; harmless when buffered)."""
-    return {"messages": [{"role": "assistant", "content": content}]}
+    """A progress event on a side-channel that vanilla OpenAI clients drop.
+
+    Deliberately carries no ``messages``/``message``/``choices`` key, so
+    ``swarm.views.chat_views._extract_message_from_chunk`` returns None and the
+    line never leaks into the synthesized answer. Swarm-aware UIs can render it
+    by inspecting ``chunk["type"] == PROGRESS_TYPE``.
+    """
+    return {"type": PROGRESS_TYPE, "content": content}
+
+
+def progress_text(chunk: dict) -> str | None:
+    """Return the text of a progress chunk, or None if it isn't one."""
+    if isinstance(chunk, dict) and chunk.get("type") == PROGRESS_TYPE:
+        return chunk.get("content")
+    return None
 
 
 def format_cli_error(adapter: CliAdapter, error: str) -> str:

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -70,6 +70,12 @@ class CliAgentConfig:
     env:
         Extra environment variables (values may contain ``{prompt}``/``{workdir}``).
         Merged onto the parent environment.
+    env_allowlist:
+        When None (default), the child inherits the full parent environment —
+        convenient, but every panelist then sees every API key. When set to a
+        list of names, the child gets only those vars (plus a small essential
+        set like ``PATH``/``HOME``) from the parent, isolating each CLI's
+        secrets. ``env`` is always applied on top.
     timeout:
         Seconds before the agent (and its process group) is killed.
     mode:
@@ -84,6 +90,7 @@ class CliAgentConfig:
     parse: str = "text"
     cwd: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    env_allowlist: list[str] | None = None
     timeout: float = DEFAULT_TIMEOUT
     mode: str = "default"
 
@@ -126,6 +133,7 @@ class CliResult:
             "timed_out": self.timed_out,
             "parse_error": self.parse_error,
             "error": self.error,
+            "stderr": self.stderr,
         }
 
 
@@ -175,6 +183,7 @@ class CliAdapter:
             parse=raw.get("parse", "text"),
             cwd=raw.get("cwd"),
             env=dict(raw.get("env", {})),
+            env_allowlist=raw.get("env_allowlist"),
             timeout=float(raw.get("timeout", DEFAULT_TIMEOUT)),
             mode=raw.get("mode", "default"),
         )
@@ -240,11 +249,7 @@ class CliAdapter:
         )
         argv, stdin_bytes = self._build_invocation(prompt, effective_workdir)
 
-        env = os.environ.copy()
-        for key, val in cfg.env.items():
-            env[key] = _apply_tokens(val, prompt, effective_workdir)
-        if extra_env:
-            env.update(extra_env)
+        env = self._build_env(prompt, effective_workdir, extra_env)
 
         if not self.is_available():
             return CliResult(
@@ -304,6 +309,24 @@ class CliAdapter:
             name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
             parse_error=parse_error, stderr=stderr.strip(),
         )
+
+    # Always-passed vars so a locked-down CLI can still run and resolve itself.
+    _ESSENTIAL_ENV = ("PATH", "HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "TMPDIR", "SHELL", "TERM")
+
+    def _build_env(
+        self, prompt: str, workdir: str, extra_env: dict[str, str] | None
+    ) -> dict[str, str]:
+        cfg = self.config
+        if cfg.env_allowlist is None:
+            env = os.environ.copy()
+        else:
+            keep = (*self._ESSENTIAL_ENV, *cfg.env_allowlist)
+            env = {k: os.environ[k] for k in keep if k in os.environ}
+        for key, val in cfg.env.items():
+            env[key] = _apply_tokens(val, prompt, workdir)
+        if extra_env:
+            env.update(extra_env)
+        return env
 
     @staticmethod
     async def _terminate(proc: asyncio.subprocess.Process) -> None:

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -1,0 +1,376 @@
+"""CLI agent adapter layer.
+
+Turns an external, interactive agentic CLI (``claude``, ``gemini``, ``codex``,
+``opencode`` ...) into a one-shot, awaitable subagent that takes a prompt and
+returns text. This is the building block the CLI-fusion blueprints compose:
+each panelist is a :class:`CliAdapter` driven entirely by configuration.
+
+Design notes
+------------
+* **No shell.** The command is an argv list executed directly
+  (``asyncio.create_subprocess_exec``); the prompt is passed as a discrete
+  argument or on stdin, so there is no shell-injection surface.
+* **Lifecycle.** Every launch runs in its own process *session*
+  (``start_new_session=True``) so a hung or runaway agent — and any children it
+  spawned — can be killed as a group on timeout.
+* **Config-driven.** Adapters are described as plain dicts (see
+  :meth:`CliAdapter.from_config`) so adding a new CLI is a config edit, not code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import signal
+import time
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Sentinel substituted in argv / cwd / env templates.
+PROMPT_TOKEN = "{prompt}"
+WORKDIR_TOKEN = "{workdir}"
+
+DEFAULT_TIMEOUT = 180.0
+# Grace period between SIGTERM and SIGKILL when reaping a timed-out agent.
+TERM_GRACE = 5.0
+
+
+class CliAdapterError(Exception):
+    """Raised for configuration/lookup problems (not runtime CLI failures)."""
+
+
+@dataclass(frozen=True)
+class CliAgentConfig:
+    """Declarative description of how to run one agentic CLI one-shot.
+
+    Attributes
+    ----------
+    name:
+        Logical adapter name (e.g. ``"claude"``).
+    cmd:
+        argv list. Use ``{prompt}`` where the prompt should be injected and
+        ``{workdir}`` for the working directory. When ``prompt_mode == "stdin"``
+        the ``{prompt}`` token is optional and the prompt is written to stdin.
+    prompt_mode:
+        ``"arg"`` (default) substitutes ``{prompt}`` into ``cmd``; ``"stdin"``
+        feeds the prompt to the process's standard input.
+    parse:
+        ``"text"`` returns trimmed stdout. ``"json:<dotpath>"`` parses stdout as
+        JSON and extracts the value at the dotted path (e.g. ``json:.result`` or
+        ``json:.choices.0.message.content``). On parse failure the raw stdout is
+        returned and ``CliResult.parse_error`` is set.
+    cwd:
+        Working directory template (``{workdir}`` allowed). When None, the
+        per-call ``workdir`` is used, else the current directory.
+    env:
+        Extra environment variables (values may contain ``{prompt}``/``{workdir}``).
+        Merged onto the parent environment.
+    timeout:
+        Seconds before the agent (and its process group) is killed.
+    mode:
+        Informational label describing the safety posture (e.g. ``"readonly"``,
+        ``"write"``). Not enforced here — it documents intent and is surfaced in
+        results/logs.
+    """
+
+    name: str
+    cmd: list[str]
+    prompt_mode: str = "arg"
+    parse: str = "text"
+    cwd: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    timeout: float = DEFAULT_TIMEOUT
+    mode: str = "default"
+
+    def __post_init__(self) -> None:
+        if not self.cmd:
+            raise CliAdapterError(f"CLI adapter '{self.name}' has an empty cmd")
+        if self.prompt_mode not in ("arg", "stdin"):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': prompt_mode must be 'arg' or 'stdin', "
+                f"got {self.prompt_mode!r}"
+            )
+        if self.prompt_mode == "arg" and not any(PROMPT_TOKEN in part for part in self.cmd):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': prompt_mode 'arg' requires a "
+                f"'{PROMPT_TOKEN}' token somewhere in cmd"
+            )
+
+
+@dataclass
+class CliResult:
+    """Outcome of a single CLI agent invocation."""
+
+    name: str
+    ok: bool
+    text: str
+    returncode: int | None = None
+    duration: float = 0.0
+    timed_out: bool = False
+    parse_error: str | None = None
+    error: str | None = None
+    stderr: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "ok": self.ok,
+            "text": self.text,
+            "returncode": self.returncode,
+            "duration": round(self.duration, 3),
+            "timed_out": self.timed_out,
+            "parse_error": self.parse_error,
+            "error": self.error,
+        }
+
+
+def _apply_tokens(value: str, prompt: str, workdir: str) -> str:
+    return value.replace(PROMPT_TOKEN, prompt).replace(WORKDIR_TOKEN, workdir)
+
+
+def _extract_json_path(data: Any, dotpath: str) -> Any:
+    """Navigate a dotted path into parsed JSON. Supports list indices.
+
+    ``.result`` -> data["result"]; ``.choices.0.message.content`` walks the list.
+    Leading dot optional. Raises KeyError/IndexError/TypeError on a bad path.
+    """
+    cur = data
+    for key in dotpath.strip(".").split("."):
+        if key == "":
+            continue
+        if isinstance(cur, list):
+            cur = cur[int(key)]
+        else:
+            cur = cur[key]
+    return cur
+
+
+class CliAdapter:
+    """Runs one configured agentic CLI as an awaitable one-shot subagent."""
+
+    def __init__(self, config: CliAgentConfig):
+        self.config = config
+
+    @property
+    def name(self) -> str:
+        return self.config.name
+
+    @classmethod
+    def from_config(cls, name: str, raw: dict[str, Any]) -> CliAdapter:
+        """Build an adapter from a config dict (see :class:`CliAgentConfig`)."""
+        if not isinstance(raw, dict):
+            raise CliAdapterError(f"CLI adapter '{name}' config must be a dict")
+        cmd = raw.get("cmd")
+        if not isinstance(cmd, list) or not all(isinstance(p, str) for p in cmd):
+            raise CliAdapterError(f"CLI adapter '{name}': 'cmd' must be a list of strings")
+        cfg = CliAgentConfig(
+            name=name,
+            cmd=list(cmd),
+            prompt_mode=raw.get("prompt_mode", "arg"),
+            parse=raw.get("parse", "text"),
+            cwd=raw.get("cwd"),
+            env=dict(raw.get("env", {})),
+            timeout=float(raw.get("timeout", DEFAULT_TIMEOUT)),
+            mode=raw.get("mode", "default"),
+        )
+        return cls(cfg)
+
+    def is_available(self) -> bool:
+        """True when the CLI executable is resolvable on PATH (or absolute)."""
+        exe = self.config.cmd[0]
+        if os.path.sep in exe:
+            return os.path.isfile(exe) and os.access(exe, os.X_OK)
+        return shutil.which(exe) is not None
+
+    def _build_invocation(
+        self, prompt: str, workdir: str
+    ) -> tuple[list[str], bytes | None]:
+        """Return (argv, stdin_bytes) for the given prompt."""
+        argv = [_apply_tokens(part, prompt, workdir) for part in self.config.cmd]
+        stdin_bytes: bytes | None = None
+        if self.config.prompt_mode == "stdin":
+            stdin_bytes = prompt.encode("utf-8")
+        return argv, stdin_bytes
+
+    def _parse_output(self, stdout: str) -> tuple[str, str | None]:
+        """Return (text, parse_error). parse_error is None on success."""
+        spec = self.config.parse or "text"
+        if spec == "text":
+            return stdout.strip(), None
+        if spec.startswith("json"):
+            dotpath = spec[len("json"):].lstrip(":")
+            try:
+                data = json.loads(stdout)
+            except json.JSONDecodeError as exc:
+                return stdout.strip(), f"invalid JSON: {exc}"
+            if not dotpath:
+                return (
+                    data if isinstance(data, str) else json.dumps(data),
+                    None,
+                )
+            try:
+                value = _extract_json_path(data, dotpath)
+            except (KeyError, IndexError, TypeError, ValueError) as exc:
+                return stdout.strip(), f"json path '{dotpath}' not found: {exc}"
+            return (value if isinstance(value, str) else json.dumps(value)), None
+        return stdout.strip(), f"unknown parse spec {spec!r}"
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        workdir: str | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> CliResult:
+        """Launch the CLI, await its answer, and parse the result.
+
+        Never raises for runtime failures — a non-zero exit, timeout, or missing
+        executable comes back as a :class:`CliResult` with ``ok=False``.
+        """
+        cfg = self.config
+        effective_workdir = (
+            _apply_tokens(cfg.cwd, prompt, workdir or os.getcwd())
+            if cfg.cwd
+            else (workdir or os.getcwd())
+        )
+        argv, stdin_bytes = self._build_invocation(prompt, effective_workdir)
+
+        env = os.environ.copy()
+        for key, val in cfg.env.items():
+            env[key] = _apply_tokens(val, prompt, effective_workdir)
+        if extra_env:
+            env.update(extra_env)
+
+        if not self.is_available():
+            return CliResult(
+                name=cfg.name,
+                ok=False,
+                text="",
+                error=f"executable not found on PATH: {cfg.cmd[0]!r}",
+            )
+
+        start = time.monotonic()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=effective_workdir,
+                env=env,
+                start_new_session=True,  # own process group, so we can kill the tree
+            )
+        except (OSError, ValueError) as exc:
+            return CliResult(
+                name=cfg.name, ok=False, text="",
+                error=f"failed to launch: {exc}", duration=time.monotonic() - start,
+            )
+
+        timed_out = False
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(input=stdin_bytes), timeout=cfg.timeout
+            )
+        except asyncio.TimeoutError:
+            timed_out = True
+            await self._terminate(proc)
+            stdout_b, stderr_b = b"", b""
+        duration = time.monotonic() - start
+
+        stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+        stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+
+        if timed_out:
+            return CliResult(
+                name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
+                duration=duration, timed_out=True, stderr=stderr.strip(),
+                error=f"timed out after {cfg.timeout}s",
+            )
+
+        if proc.returncode != 0:
+            return CliResult(
+                name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
+                duration=duration, stderr=stderr.strip(),
+                error=f"exited {proc.returncode}: {stderr.strip()[:500]}",
+            )
+
+        text, parse_error = self._parse_output(stdout)
+        return CliResult(
+            name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
+            parse_error=parse_error, stderr=stderr.strip(),
+        )
+
+    @staticmethod
+    async def _terminate(proc: asyncio.subprocess.Process) -> None:
+        """Kill a timed-out process group: SIGTERM, grace, then SIGKILL."""
+        if proc.returncode is not None:
+            return
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            return
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(pgid, sig)
+            except ProcessLookupError:
+                return
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=TERM_GRACE)
+                return
+            except asyncio.TimeoutError:
+                continue
+
+
+class CliAdapterRegistry:
+    """Holds the configured CLI adapters and resolves them by name."""
+
+    def __init__(self, adapters: dict[str, CliAdapter] | None = None):
+        self._adapters: dict[str, CliAdapter] = adapters or {}
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None) -> CliAdapterRegistry:
+        """Build a registry from the top-level swarm config's ``cli_agents`` block."""
+        adapters: dict[str, CliAdapter] = {}
+        raw_agents = (config or {}).get("cli_agents", {}) or {}
+        for name, raw in raw_agents.items():
+            try:
+                adapters[name] = CliAdapter.from_config(name, raw)
+            except CliAdapterError as exc:
+                logger.warning("Skipping CLI adapter %r: %s", name, exc)
+        return cls(adapters)
+
+    def get(self, name: str) -> CliAdapter:
+        try:
+            return self._adapters[name]
+        except KeyError as exc:
+            raise CliAdapterError(
+                f"no CLI adapter named {name!r}; configured: {sorted(self._adapters)}"
+            ) from exc
+
+    def names(self) -> list[str]:
+        return sorted(self._adapters)
+
+    def available(self) -> list[str]:
+        """Names of adapters whose executable is present on this host."""
+        return sorted(n for n, a in self._adapters.items() if a.is_available())
+
+    def resolve_panel(self, names: list[str]) -> list[CliAdapter]:
+        """Resolve a list of adapter names to adapters (raises on unknown)."""
+        return [self.get(n) for n in names]
+
+    def with_overrides(self, overrides: dict[str, dict[str, Any]]) -> CliAdapterRegistry:
+        """Return a copy with per-adapter field overrides applied (non-mutating)."""
+        merged = dict(self._adapters)
+        for name, patch in (overrides or {}).items():
+            base = merged.get(name)
+            cfg = base.config if base else None
+            if cfg is None:
+                merged[name] = CliAdapter.from_config(name, patch)
+            else:
+                merged[name] = CliAdapter(replace(cfg, **patch))
+        return CliAdapterRegistry(merged)

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -1,0 +1,119 @@
+"""Tests for the single-CLI blueprint (cli_agent) and shared support helpers."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from swarm.blueprints.cli_agent.blueprint_cli_agent import CliAgentBlueprint
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.cli_adapter import CliAdapterRegistry
+
+PY = sys.executable
+
+
+def _echo_config(prefix: str = "ECHO") -> dict:
+    return {
+        "cli_agents": {
+            "echo": {
+                "cmd": [PY, "-c", f"import sys; print('{prefix}: ' + sys.argv[1])", "{prompt}"],
+                "parse": "text",
+            },
+            "echo2": {
+                "cmd": [PY, "-c", "import sys; print('TWO: ' + sys.argv[1])", "{prompt}"],
+            },
+        },
+        "cli_fusion": {"default_cli": "echo"},
+    }
+
+
+async def _collect(gen):
+    chunks = []
+    async for c in gen:
+        chunks.append(c)
+    return chunks
+
+
+def _final_content(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# Support helpers
+# --------------------------------------------------------------------------- #
+
+def test_render_prompt_single():
+    assert support.render_prompt([{"role": "user", "content": "hi"}]) == "hi"
+
+
+def test_render_prompt_multiturn_transcript():
+    out = support.render_prompt(
+        [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hello"},
+        ]
+    )
+    assert "SYSTEM: be terse" in out and "USER: hello" in out
+
+
+def test_select_single_cli_priority():
+    cfg = _echo_config()
+    reg = CliAdapterRegistry.from_config(cfg)
+    # per-request param wins
+    assert support.select_single_cli(cfg, {"cli": "echo2"}, reg) == "echo2"
+    # else config default
+    assert support.select_single_cli(cfg, {}, reg) == "echo"
+
+
+def test_select_single_cli_none_when_empty():
+    reg = CliAdapterRegistry.from_config({})
+    assert support.select_single_cli({}, {}, reg) is None
+
+
+# --------------------------------------------------------------------------- #
+# Blueprint end-to-end (real subprocess)
+# --------------------------------------------------------------------------- #
+
+async def test_blueprint_runs_default_cli():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_echo_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "ECHO: ping"
+    # last chunk marked final
+    assert chunks[-1].get("final") is True
+
+
+async def test_blueprint_respects_cli_param():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_echo_config())
+    bp.set_params({"cli": "echo2"})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "TWO: ping"
+
+
+async def test_blueprint_no_agents_configured():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config={})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert "No CLI agents are configured" in _final_content(chunks)
+
+
+async def test_blueprint_empty_prompt():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_echo_config())
+    chunks = await _collect(bp.run([]))
+    assert "No prompt provided" in _final_content(chunks)
+
+
+async def test_blueprint_reports_cli_failure():
+    cfg = {
+        "cli_agents": {
+            "boom": {"cmd": [PY, "-c", "import sys; sys.exit(2)", "{prompt}"]},
+        },
+        "cli_fusion": {"default_cli": "boom"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert "failed" in _final_content(chunks)

--- a/tests/blueprints/test_cli_fusion.py
+++ b/tests/blueprints/test_cli_fusion.py
@@ -1,0 +1,183 @@
+"""Tests for the CLI Fusion blueprint (panel -> judge -> synthesize + master plan)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from swarm.blueprints.cli_fusion.blueprint_cli_fusion import (
+    CliFusionBlueprint,
+    _safe_json,
+)
+
+PY = sys.executable
+
+
+def _echo(name_prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{name_prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _judge_emitting(obj: dict) -> dict:
+    # A "judge" CLI that ignores input and prints a fixed JSON analysis.
+    payload = json.dumps(obj).replace("'", "\\'")
+    return {"cmd": [PY, "-c", f"import sys; print('{payload}')", "{prompt}"]}
+
+
+def _config(*, judge_obj=None, panel=("a", "b"), max_rounds=1, **fusion_extra) -> dict:
+    agents = {"a": _echo("A"), "b": _echo("B")}
+    fusion = {"presets": {"p": {"panel": list(panel)}}, "default_preset": "p", "max_rounds": max_rounds}
+    if judge_obj is not None:
+        agents["judge"] = _judge_emitting(judge_obj)
+        fusion["presets"]["p"]["judge"] = "judge"
+    fusion.update(fusion_extra)
+    return {"cli_agents": agents, "cli_fusion": fusion}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final_content(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _all_text(chunks):
+    return "\n".join(
+        c["messages"][0]["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("messages") and c["messages"][0].get("content")
+    )
+
+
+def _all_progress(chunks):
+    return "\n".join(
+        c["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("type") == "fusion_progress"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _safe_json
+# --------------------------------------------------------------------------- #
+
+def test_safe_json_plain():
+    assert _safe_json('{"a": 1}') == {"a": 1}
+
+
+def test_safe_json_embedded_in_prose():
+    assert _safe_json('Here you go:\n{"a": 1}\nthanks') == {"a": 1}
+
+
+def test_safe_json_garbage_returns_none():
+    assert _safe_json("no json here") is None
+    assert _safe_json("") is None
+
+
+# --------------------------------------------------------------------------- #
+# Fusion: single round
+# --------------------------------------------------------------------------- #
+
+async def test_fusion_no_agents():
+    bp = CliFusionBlueprint(config={})
+    chunks = await _collect(bp.run([{"role": "user", "content": "x"}]))
+    assert "No CLI agents are configured" in _final_content(chunks)
+
+
+async def test_fusion_judge_answer_used():
+    cfg = _config(judge_obj={"answer": "SYNTHESIZED", "done": True})
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert _final_content(chunks) == "SYNTHESIZED"
+    assert chunks[-1].get("final") is True
+
+
+async def test_fusion_fallback_without_judge():
+    # No judge: synthesize falls back to the longest successful panel answer.
+    cfg = _config(panel=("a", "b"))  # no judge_obj
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hello"}]))
+    final = _final_content(chunks)
+    assert final in ("A:hello", "B:hello")
+
+
+async def test_fusion_panel_runs_all_agents():
+    cfg = _config(judge_obj={"answer": "ok", "done": True})
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert "a, b" in _all_progress(chunks)  # progress line names both panelists
+
+
+# --------------------------------------------------------------------------- #
+# Fusion: master-plan loop
+# --------------------------------------------------------------------------- #
+
+async def test_fusion_multiround_runs_until_ceiling():
+    # Judge always says not done -> loop should run max_rounds then stop.
+    cfg = _config(judge_obj={"answer": "partial", "done": False, "next_step": "go again"}, max_rounds=2)
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    progress = _all_progress(chunks)
+    assert "Round 1/2" in progress
+    assert "Round 2/2" in progress
+    assert "next step" in progress.lower()
+    assert chunks[-1].get("final") is True
+
+
+async def test_fusion_stops_early_when_done():
+    cfg = _config(judge_obj={"answer": "final", "done": True}, max_rounds=3)
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    progress = _all_progress(chunks)
+    assert "Round 1/3" in progress
+    assert "Round 2/3" not in progress  # stopped after round 1
+
+
+async def test_max_rounds_is_capped():
+    cfg = _config(judge_obj={"answer": "x", "done": False}, max_rounds=999)
+    bp = CliFusionBlueprint(config=cfg)
+    # _max_rounds clamps to the ceiling
+    assert bp._max_rounds({}, cfg["cli_fusion"]) == 5
+
+
+# --------------------------------------------------------------------------- #
+# Fusion: failure + recursion guard
+# --------------------------------------------------------------------------- #
+
+async def test_fusion_all_panel_fail():
+    cfg = {
+        "cli_agents": {"boom": {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}},
+        "cli_fusion": {"presets": {"p": {"panel": ["boom"]}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert "All CLI panelists failed" in _final_content(chunks)
+
+
+async def test_recursion_guard_degrades(monkeypatch):
+    monkeypatch.setenv("SWARM_CLI_FUSION_DEPTH", "1")
+    cfg = _config(judge_obj={"answer": "should-not-be-used", "done": True}, panel=("a", "b"))
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "deep"}]))
+    assert "Nested fusion detected" in _all_progress(chunks)
+    # Degraded to single panelist 'a', judge skipped -> fallback answer from 'a'.
+    assert _final_content(chunks) == "A:deep"
+
+
+async def test_show_analysis_footer():
+    cfg = _config(
+        judge_obj={"answer": "core", "done": True, "consensus": ["x", "y"]},
+        show_analysis=True,
+    )
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    final = _final_content(chunks)
+    assert "core" in final
+    assert "consensus" in final

--- a/tests/blueprints/test_cli_fusion.py
+++ b/tests/blueprints/test_cli_fusion.py
@@ -151,6 +151,15 @@ async def test_max_rounds_is_capped():
 # Fusion: failure + recursion guard
 # --------------------------------------------------------------------------- #
 
+async def test_fusion_bounded_concurrency_still_runs_all():
+    cfg = _config(judge_obj={"answer": "ok", "done": True}, panel=("a", "b"), max_concurrency=1)
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    # Serialized launches still produce the synthesized answer and name both agents.
+    assert _final_content(chunks) == "ok"
+    assert "a, b" in _all_progress(chunks)
+
+
 async def test_fusion_all_panel_fail():
     cfg = {
         "cli_agents": {"boom": {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}},

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -1,0 +1,219 @@
+"""Tests for the CLI agent adapter layer (swarm.core.cli_adapter).
+
+These exercise real subprocesses using the running Python interpreter as a
+stand-in agentic CLI, so they verify the actual launch/lifecycle/parse path
+rather than a mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+import pytest
+
+from swarm.core.cli_adapter import (
+    CliAdapter,
+    CliAdapterError,
+    CliAdapterRegistry,
+    CliAgentConfig,
+)
+
+PY = sys.executable
+
+
+def _echo_cfg(**over) -> dict:
+    # Echo the prompt back, prefixed, via argv injection.
+    base = {
+        "cmd": [PY, "-c", "import sys; print('ECHO: ' + sys.argv[1])", "{prompt}"],
+        "parse": "text",
+    }
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Config validation
+# --------------------------------------------------------------------------- #
+
+def test_empty_cmd_rejected():
+    with pytest.raises(CliAdapterError):
+        CliAgentConfig(name="x", cmd=[])
+
+
+def test_arg_mode_requires_prompt_token():
+    with pytest.raises(CliAdapterError):
+        CliAgentConfig(name="x", cmd=[PY, "-c", "print(1)"])  # no {prompt}
+
+
+def test_stdin_mode_does_not_require_prompt_token():
+    cfg = CliAgentConfig(name="x", cmd=["cat"], prompt_mode="stdin")
+    assert cfg.prompt_mode == "stdin"
+
+
+def test_bad_prompt_mode_rejected():
+    with pytest.raises(CliAdapterError):
+        CliAgentConfig(name="x", cmd=["cat", "{prompt}"], prompt_mode="bogus")
+
+
+# --------------------------------------------------------------------------- #
+# Run: happy paths
+# --------------------------------------------------------------------------- #
+
+async def test_arg_mode_text():
+    adapter = CliAdapter.from_config("echo", _echo_cfg())
+    res = await adapter.run("hello world")
+    assert res.ok is True
+    assert res.text == "ECHO: hello world"
+    assert res.returncode == 0
+    assert res.parse_error is None
+
+
+async def test_stdin_mode():
+    adapter = CliAdapter.from_config(
+        "cat", {"cmd": ["cat"], "prompt_mode": "stdin", "parse": "text"}
+    )
+    res = await adapter.run("piped prompt")
+    assert res.ok is True
+    assert res.text == "piped prompt"
+
+
+async def test_json_parse_dotpath():
+    code = "import json,sys; print(json.dumps({'result': 'answer:' + sys.argv[1]}))"
+    adapter = CliAdapter.from_config(
+        "j", {"cmd": [PY, "-c", code, "{prompt}"], "parse": "json:.result"}
+    )
+    res = await adapter.run("Q")
+    assert res.ok is True
+    assert res.text == "answer:Q"
+    assert res.parse_error is None
+
+
+async def test_json_parse_nested_list_index():
+    code = (
+        "import json; "
+        "print(json.dumps({'choices':[{'message':{'content':'deep'}}]}))"
+    )
+    adapter = CliAdapter.from_config(
+        "j",
+        {"cmd": [PY, "-c", code, "{prompt}"], "parse": "json:.choices.0.message.content"},
+    )
+    res = await adapter.run("ignored")
+    assert res.ok is True
+    assert res.text == "deep"
+
+
+async def test_json_parse_failure_falls_back_to_raw():
+    adapter = CliAdapter.from_config(
+        "j", {"cmd": [PY, "-c", "print('not json')", "{prompt}"], "parse": "json:.result"}
+    )
+    res = await adapter.run("Q")
+    # Still "ok" (process succeeded); parse_error records the problem.
+    assert res.ok is True
+    assert res.parse_error is not None
+    assert res.text == "not json"
+
+
+# --------------------------------------------------------------------------- #
+# Run: failure modes
+# --------------------------------------------------------------------------- #
+
+async def test_nonzero_exit_is_not_ok():
+    code = "import sys; sys.stderr.write('boom'); sys.exit(3)"
+    adapter = CliAdapter.from_config("f", {"cmd": [PY, "-c", code, "{prompt}"]})
+    res = await adapter.run("x")
+    assert res.ok is False
+    assert res.returncode == 3
+    assert "boom" in (res.error or "")
+
+
+async def test_missing_executable_is_not_ok():
+    adapter = CliAdapter.from_config(
+        "missing", {"cmd": ["this-cli-does-not-exist-xyz", "{prompt}"]}
+    )
+    res = await adapter.run("x")
+    assert res.ok is False
+    assert "not found" in (res.error or "")
+
+
+async def test_timeout_kills_and_reports():
+    # Sleep far longer than the timeout; must come back quickly as timed_out.
+    code = "import time; time.sleep(30)"
+    adapter = CliAdapter.from_config(
+        "slow", {"cmd": [PY, "-c", code, "{prompt}"], "timeout": 0.4}
+    )
+    start = time.monotonic()
+    res = await adapter.run("x")
+    elapsed = time.monotonic() - start
+    assert res.ok is False
+    assert res.timed_out is True
+    # Should be killed shortly after the 0.4s timeout, not run for 30s.
+    assert elapsed < 10
+
+
+async def test_extra_env_passed_through():
+    code = "import os,sys; print(os.environ.get('SWARM_TEST_VAR', 'unset'))"
+    adapter = CliAdapter.from_config("e", {"cmd": [PY, "-c", code, "{prompt}"]})
+    res = await adapter.run("x", extra_env={"SWARM_TEST_VAR": "present"})
+    assert res.ok is True
+    assert res.text == "present"
+
+
+# --------------------------------------------------------------------------- #
+# Parallel panel semantics
+# --------------------------------------------------------------------------- #
+
+async def test_parallel_panel_gather():
+    adapters = [CliAdapter.from_config(f"a{i}", _echo_cfg()) for i in range(4)]
+    results = await asyncio.gather(*(a.run(f"p{i}") for i, a in enumerate(adapters)))
+    assert [r.text for r in results] == [f"ECHO: p{i}" for i in range(4)]
+    assert all(r.ok for r in results)
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+def test_registry_from_config_and_lookup():
+    reg = CliAdapterRegistry.from_config(
+        {"cli_agents": {"echo": _echo_cfg(), "cat": {"cmd": ["cat"], "prompt_mode": "stdin"}}}
+    )
+    assert reg.names() == ["cat", "echo"]
+    assert reg.get("echo").name == "echo"
+    with pytest.raises(CliAdapterError):
+        reg.get("nope")
+
+
+def test_registry_skips_invalid_adapters():
+    reg = CliAdapterRegistry.from_config(
+        {"cli_agents": {"good": _echo_cfg(), "bad": {"cmd": []}}}
+    )
+    assert reg.names() == ["good"]
+
+
+def test_registry_available_filters_missing():
+    reg = CliAdapterRegistry.from_config(
+        {
+            "cli_agents": {
+                "real": _echo_cfg(),
+                "ghost": {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]},
+            }
+        }
+    )
+    avail = reg.available()
+    assert "real" in avail
+    assert "ghost" not in avail
+
+
+def test_registry_resolve_panel():
+    reg = CliAdapterRegistry.from_config({"cli_agents": {"a": _echo_cfg(), "b": _echo_cfg()}})
+    panel = reg.resolve_panel(["a", "b"])
+    assert [a.name for a in panel] == ["a", "b"]
+
+
+def test_with_overrides_is_non_mutating():
+    reg = CliAdapterRegistry.from_config({"cli_agents": {"echo": _echo_cfg(timeout=5)}})
+    reg2 = reg.with_overrides({"echo": {"timeout": 99}})
+    assert reg.get("echo").config.timeout == 5
+    assert reg2.get("echo").config.timeout == 99

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -160,6 +160,39 @@ async def test_extra_env_passed_through():
     assert res.text == "present"
 
 
+async def test_env_allowlist_isolates_secrets(monkeypatch):
+    # A secret in the parent env must NOT reach the child when an allowlist is set.
+    monkeypatch.setenv("FAKE_SECRET_KEY", "topsecret")
+    monkeypatch.setenv("ALLOWED_VAR", "ok")
+    code = (
+        "import os; "
+        "print(os.environ.get('FAKE_SECRET_KEY', 'absent'), "
+        "os.environ.get('ALLOWED_VAR', 'absent'))"
+    )
+    adapter = CliAdapter.from_config(
+        "locked",
+        {"cmd": [PY, "-c", code, "{prompt}"], "env_allowlist": ["ALLOWED_VAR"]},
+    )
+    res = await adapter.run("x")
+    assert res.ok is True
+    assert res.text == "absent ok"  # secret scrubbed, allowed var kept
+
+
+async def test_no_allowlist_inherits_full_env(monkeypatch):
+    monkeypatch.setenv("FAKE_SECRET_KEY", "topsecret")
+    code = "import os; print(os.environ.get('FAKE_SECRET_KEY', 'absent'))"
+    adapter = CliAdapter.from_config("open", {"cmd": [PY, "-c", code, "{prompt}"]})
+    res = await adapter.run("x")
+    assert res.text == "topsecret"
+
+
+def test_result_as_dict_includes_stderr():
+    from swarm.core.cli_adapter import CliResult
+
+    d = CliResult(name="x", ok=False, text="", stderr="boom").as_dict()
+    assert d["stderr"] == "boom"
+
+
 # --------------------------------------------------------------------------- #
 # Parallel panel semantics
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## CLI Agent Fusion — foundation (Release v0.4.0, PR 1)

Repositions open-swarm around a category nobody else occupies: an **OpenAI-compatible endpoint where the "models" are whatever agentic CLIs you have installed** (`claude`, `gemini`, `codex`, `opencode`, `letta`, `vibe`, `kilocode`, `agy`). Inspired by OpenRouter Fusion — but the panelists are your local toolbox, so the multi-model quality story comes **without** Fusion's 4–5× frontier-API cost.

### What's in this PR (foundation)
- **`CliAdapter` lifecycle core** (`src/swarm/core/cli_adapter.py`) — config-driven async one-shot runner for any CLI: argv/stdin prompt injection, `text`/`json:dotpath` parsing, hard timeout with process-group kill, opt-in `env_allowlist` secret isolation, and a registry with on-host availability filtering.
- **`cli_agent` blueprint** — expose one CLI over `/v1/chat/completions` (`model: "cli_agent"`).
- **`cli_fusion` blueprint** — parallel panel → judge → synthesize, with a bounded master-plan loop (judge `done`/`next_step` drives rounds), recursion guard, bounded concurrency, no-judge fallback.
- **Docs** — `docs/CLI_FUSION.md`, `docs/examples/cli_fusion.swarm_config.json`, README pointer.

### Reviewing this PR
The 5 commits are individually meaningful and can be reviewed in order:
1. `cli_adapter` core + tests
2. `cli_agent` blueprint + shared support helpers
3. `cli_fusion` blueprint + folded-in architecture/cleanup review fixes
4. docs + example config
5. bounded panel concurrency + roadmap

### Tests
45 CLI-fusion tests + 244 core + 99 blueprint/API suites green; no regressions. Real-host availability validated (`claude`/`gemini`/`opencode` detected).

### Follows in this release (planned, separate PRs)
- Autodiscovery: detect which CLIs are **installed** and **authenticated**, surfaced via `/v1/models` + a CLI command
- One adapter-preset PR per target CLI (letta, opencode, vibe, kilocode, gemini, agy, codex, claude) with per-CLI validation notes
- `FusionOrchestrator` core-service extraction
- CHANGELOG + version bump to 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
