### PR TITLE
feat: CLI install autodiscovery — swarm-cli cli-agents (v0.4.0 PR 2)

### DIFF
--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -44,6 +44,23 @@ curl -sf http://localhost:8000/v1/chat/completions \
 `params` is the standard Open Swarm per-request field; OpenAI SDKs send it via
 `extra_body={"params": {...}}`.
 
+### Autodiscovery
+
+See which of your configured CLIs are actually installed on the host:
+
+```bash
+swarm-cli cli-agents          # uses the usual config search
+swarm-cli cli-agents --config ./swarm_config.json
+```
+
+```
+AGENT            STATUS     MODE       EXECUTABLE
+claude           installed  readonly   /home/you/.local/bin/claude
+codex            missing    readonly   -
+gemini           installed  readonly   /home/you/.nvm/.../gemini
+3/4 configured CLI agents installed on this host.
+```
+
 ---
 
 ## Config: `cli_agents`

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -349,6 +349,24 @@ class CliAdapter:
                 continue
 
 
+@dataclass
+class CliDiscovery:
+    """Autodiscovery status for one configured CLI adapter."""
+
+    name: str
+    installed: bool
+    executable: str | None
+    mode: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "installed": self.installed,
+            "executable": self.executable,
+            "mode": self.mode,
+        }
+
+
 class CliAdapterRegistry:
     """Holds the configured CLI adapters and resolves them by name."""
 
@@ -381,6 +399,23 @@ class CliAdapterRegistry:
     def available(self) -> list[str]:
         """Names of adapters whose executable is present on this host."""
         return sorted(n for n, a in self._adapters.items() if a.is_available())
+
+    def discover(self) -> list[CliDiscovery]:
+        """Report install status for every configured adapter (sorted by name)."""
+        out: list[CliDiscovery] = []
+        for name in self.names():
+            cfg = self._adapters[name].config
+            exe = cfg.cmd[0]
+            resolved = exe if os.path.sep in exe else shutil.which(exe)
+            out.append(
+                CliDiscovery(
+                    name=name,
+                    installed=self._adapters[name].is_available(),
+                    executable=resolved,
+                    mode=cfg.mode,
+                )
+            )
+        return out
 
     def resolve_panel(self, names: list[str]) -> list[CliAdapter]:
         """Resolve a list of adapter names to adapters (raises on unknown)."""

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -271,5 +271,29 @@ def list_blueprints(
         typer.echo("")
 
 
+@app.command(name="cli-agents")
+def cli_agents(
+    config_path: str = typer.Option(None, "--config", help="Path to swarm_config.json (defaults to the usual search)."),
+):
+    """Autodiscover configured CLI agents and show which are installed on this host."""
+    from swarm.core.cli_adapter import CliAdapterRegistry
+    from swarm.core.config_loader import find_config_file, load_config
+
+    cfg_file = find_config_file(specific_path=config_path)
+    config = load_config(cfg_file) if cfg_file else {}
+    registry = CliAdapterRegistry.from_config(config)
+    rows = registry.discover()
+    if not rows:
+        typer.echo("No CLI agents configured. Add a 'cli_agents' block to your swarm config (see docs/CLI_FUSION.md).")
+        raise typer.Exit(code=0)
+
+    typer.echo(f"{'AGENT':16} {'STATUS':10} {'MODE':10} EXECUTABLE")
+    for d in rows:
+        status = "installed" if d.installed else "missing"
+        typer.echo(f"{d.name:16} {status:10} {d.mode:10} {d.executable or '-'}")
+    installed = sum(1 for d in rows if d.installed)
+    typer.echo(f"\n{installed}/{len(rows)} configured CLI agents installed on this host.")
+
+
 if __name__ == "__main__":
     app()

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -245,6 +245,27 @@ def test_registry_resolve_panel():
     assert [a.name for a in panel] == ["a", "b"]
 
 
+def test_discover_reports_install_status():
+    reg = CliAdapterRegistry.from_config(
+        {
+            "cli_agents": {
+                "real": {**_echo_cfg(), "mode": "readonly"},
+                "ghost": {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]},
+            }
+        }
+    )
+    rows = {d.name: d for d in reg.discover()}
+    assert rows["real"].installed is True
+    assert rows["real"].executable is not None
+    assert rows["real"].mode == "readonly"
+    assert rows["ghost"].installed is False
+    assert rows["ghost"].executable is None
+
+
+def test_discover_empty_registry():
+    assert CliAdapterRegistry.from_config({}).discover() == []
+
+
 def test_with_overrides_is_non_mutating():
     reg = CliAdapterRegistry.from_config({"cli_agents": {"echo": _echo_cfg(timeout=5)}})
     reg2 = reg.with_overrides({"echo": {"timeout": 99}})


### PR DESCRIPTION
## CLI install autodiscovery (Release v0.4.0, PR 2)

Adds the first half of autodiscovery: detect which configured CLI agents are actually **installed** on the host.

### What's in this PR
- `CliAdapterRegistry.discover()` → per-adapter `CliDiscovery {name, installed, executable, mode}`.
- `swarm-cli cli-agents [--config PATH]` — loads the swarm config (usual search or explicit path) and prints an install table:

```
AGENT            STATUS     MODE       EXECUTABLE
claude           installed  readonly   /home/you/.local/bin/claude
codex            missing    readonly   -
gemini           installed  readonly   /home/you/.nvm/.../gemini
3/4 configured CLI agents installed on this host.
```

- Documented in `docs/CLI_FUSION.md`.

### Tests
24 adapter tests green (adds `discover()` coverage). Verified live: the command correctly reports `claude`/`gemini`/`opencode` installed and `codex` missing on this host.

### Next
PR 3 adds the **authentication** probe (`auth_check`), so discovery reports installed + authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
